### PR TITLE
Update env usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # KIBA
+
+## Environment Variables
+
+The backend relies on several environment variables:
+
+- `DATABASE_URL` &ndash; SQLAlchemy connection string for the application's database.
+- `HABLAME_ACCOUNT` &ndash; account identifier for the Hablame SMS API.
+- `HABLAME_APIKEY` &ndash; API key for the Hablame SMS API.
+- `HABLAME_TOKEN` &ndash; authentication token for the Hablame SMS API.
+
+Make sure these variables are defined before running the application.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -11,8 +11,8 @@ def create_app():
     app = Flask(__name__)
     CORS(app)
 
-    # ✅ Usa la conexión real a XAMPP
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'mysql+pymysql://root:@localhost/kiba'
+    # Lee la cadena de conexión desde la variable de entorno DATABASE_URL
+    app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('DATABASE_URL')
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
     app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'clave-super-secreta-kiba')
 

--- a/backend/app/routes/sms.py
+++ b/backend/app/routes/sms.py
@@ -19,9 +19,9 @@ sms_bp = Blueprint('sms', __name__)
 def obtener_headers():
     return {
         "Content-Type": "application/json",
-        "Account": os.getenv("HABLAME_ACCOUNT", "10011703"),
-        "ApiKey": os.getenv("HABLAME_APIKEY", "Tp0EeAGxwUSpe7V5lWJTANldwNnnrK"),
-        "Token": os.getenv("HABLAME_TOKEN", "932e1c975331854f7ead1bd54ded2969")
+        "Account": os.getenv("HABLAME_ACCOUNT"),
+        "ApiKey": os.getenv("HABLAME_APIKEY"),
+        "Token": os.getenv("HABLAME_TOKEN")
     }
 
 # ========================


### PR DESCRIPTION
## Summary
- read database URL from the `DATABASE_URL` environment variable
- remove default HablaMe credentials
- document environment variables in README

## Testing
- `git ls-files '*.py' | xargs python -m py_compile`


------
https://chatgpt.com/codex/tasks/task_e_6848fd0e32288320a722230280050a2a