### PR TITLE
Fix blueprint registration prefix

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,15 +10,17 @@ from backend.app.routes.paciente import paciente_bp
 from backend.app.routes.cita import cita_bp
 from flask_migrate import Migrate
 from backend.app.routes.confirmacion import confirmacion_bp
+from backend.app.routes.sms import sms_bp
 
 
 app = create_app()
-app.register_blueprint(auth_bp)
-app.register_blueprint(specialty_bp)
-app.register_blueprint(paciente_bp)
-app.register_blueprint(cita_bp)
+app.register_blueprint(auth_bp, url_prefix='/api')
+app.register_blueprint(specialty_bp, url_prefix='/api')
+app.register_blueprint(paciente_bp, url_prefix='/api')
+app.register_blueprint(cita_bp, url_prefix='/api')
+app.register_blueprint(sms_bp, url_prefix='/api')
 migrate = Migrate(app, db)
-app.register_blueprint(confirmacion_bp)
+app.register_blueprint(confirmacion_bp, url_prefix='/api')
 
 
 @app.route('/')


### PR DESCRIPTION
## Summary
- register sms routes in main application
- apply `/api` url_prefix to all blueprints

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6848fd0cbbac8320ba4a14fca39c936e