### PR TITLE
Use env var for secret key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # KIBA
+
+Este proyecto requiere la variable de entorno `SECRET_KEY` para firmar los tokens JWT.
+
+## Desarrollo
+
+Puedes definirla temporalmente en tu terminal antes de ejecutar la aplicación:
+
+```bash
+export SECRET_KEY="tu_clave_de_desarrollo"
+```
+
+## Producción
+
+En producción se recomienda establecer `SECRET_KEY` como una variable de entorno del sistema o utilizar herramientas de gestión de secretos para asignar un valor seguro.
+

--- a/backend/app/utils/token_manager.py
+++ b/backend/app/utils/token_manager.py
@@ -1,5 +1,6 @@
 # backend/app/utils/token_manager.py
 
+import os
 import jwt
 import datetime
 from flask import request, jsonify
@@ -7,7 +8,7 @@ from backend.app.config import db
 from backend.app.models.user import Usuario
 
 # Clave secreta para firmar el Token JWT
-SECRET_KEY = 'clave-super-secreta-kiba'  # (más adelante podemos moverla a .env para producción)
+SECRET_KEY = os.environ.get('SECRET_KEY', 'clave-super-secreta-kiba')
 
 # Función para generar el token
 def generar_token(usuario):


### PR DESCRIPTION
## Summary
- read SECRET_KEY from environment in token manager
- document configuring SECRET_KEY in README

## Testing
- `python -m py_compile backend/app/utils/token_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_6848fd0725188320ab5a503d0c59701d