### PR TITLE
Fix imports for manage CLI

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,7 +1,8 @@
 # KIBA/manage.py
 from backend.app.main import app
 from backend.app.config import db
-from flask_migrate import Migrate
+from flask_migrate import Migrate, MigrateCommand
+from flask_script import Manager
 
 
 # Configura Migrate


### PR DESCRIPTION
## Summary
- add missing Manager and MigrateCommand imports for Flask CLI

## Testing
- `python manage.py --help` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6848fd03f238832093f666124285776a