### PR TITLE
Implement React auth context and API helpers

### DIFF
--- a/frontend/src/AuthContext.jsx
+++ b/frontend/src/AuthContext.jsx
@@ -1,0 +1,35 @@
+import React, { createContext, useContext, useState } from 'react';
+
+const AuthContext = createContext({ token: null, user: null });
+
+export function AuthProvider({ children }) {
+  const [token, setToken] = useState(() => localStorage.getItem('token'));
+  const [user, setUser] = useState(() => {
+    const data = localStorage.getItem('user');
+    return data ? JSON.parse(data) : null;
+  });
+
+  const login = (newToken, userInfo) => {
+    setToken(newToken);
+    setUser(userInfo);
+    localStorage.setItem('token', newToken);
+    localStorage.setItem('user', JSON.stringify(userInfo));
+  };
+
+  const logout = () => {
+    setToken(null);
+    setUser(null);
+    localStorage.removeItem('token');
+    localStorage.removeItem('user');
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  return useContext(AuthContext);
+}

--- a/frontend/src/ProtectedRoute.jsx
+++ b/frontend/src/ProtectedRoute.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuth } from './AuthContext';
+
+export default function ProtectedRoute({ children }) {
+  const { token } = useAuth();
+  if (!token) {
+    return <Navigate to="/login" replace />;
+  }
+  return children;
+}

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,0 +1,15 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: 'http://localhost:5000/api'
+});
+
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem('token');
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+export default api;

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import axios from 'axios';
+import api from '../api';
 import { Bar } from 'react-chartjs-2';
 import {
   Chart as ChartJS,
@@ -23,7 +23,7 @@ export default function Dashboard() {
   });
 
   useEffect(() => {
-    axios.get('http://localhost:5000/api/dashboard')
+    api.get('/dashboard')
       .then(res => setEstadisticas(res.data))
       .catch(err => console.error('Error cargando dashboard:', err));
   }, []);

--- a/frontend/src/pages/ImportSMS.jsx
+++ b/frontend/src/pages/ImportSMS.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import * as XLSX from 'xlsx';
-import axios from 'axios';
+import api from '../api';
 
 export default function ImportSMS() {
   const [archivo, setArchivo] = useState(null);
@@ -24,7 +24,7 @@ export default function ImportSMS() {
 
   const enviarSMSMasivos = async () => {
     try {
-      const response = await axios.post('http://localhost:5000/api/importar-sms', {
+      const response = await api.post('/importar-sms', {
         mensajes: datos,
       });
 

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,24 +1,26 @@
 // frontend/src/pages/Login.jsx
 import React, { useState } from 'react';
-import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
+import api from '../api';
+import { useAuth } from '../AuthContext';
 
 export default function Login() {
   const [correo, setCorreo] = useState('');
   const [contrasena, setContrasena] = useState('');
   const [error, setError] = useState('');
   const navigate = useNavigate();
+  const { login } = useAuth();
 
   const handleLogin = async (e) => {
     e.preventDefault();
     try {
-      const response = await axios.post('http://localhost:5000/api/login', {
+      const response = await api.post('/login', {
         correo,
         contrasena
       });
 
-      if (response.data.success) {
-        localStorage.setItem('usuario', JSON.stringify(response.data));
+      if (response.data.token) {
+        login(response.data.token, { correo, rol: response.data.rol });
         navigate('/dashboard');
       }
     } catch (err) {

--- a/frontend/src/pages/Reports.jsx
+++ b/frontend/src/pages/Reports.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import axios from 'axios';
+import api from '../api';
 import * as XLSX from 'xlsx';
 import { saveAs } from 'file-saver';
 import jsPDF from 'jspdf';
@@ -9,7 +9,7 @@ export default function Reports() {
   const [historial, setHistorial] = useState([]);
 
   useEffect(() => {
-    axios.get('http://localhost:5000/api/historial')
+    api.get('/historial')
       .then(res => setHistorial(res.data))
       .catch(err => console.error('Error al cargar historial:', err));
   }, []);

--- a/frontend/src/pages/SendSMS.jsx
+++ b/frontend/src/pages/SendSMS.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import axios from 'axios';
+import api from '../api';
 
 export default function SendSMS() {
   const [numero, setNumero] = useState('');
@@ -13,7 +13,7 @@ export default function SendSMS() {
     setRespuesta(null);
 
     try {
-      const res = await axios.post('http://localhost:5000/api/enviar-sms', {
+      const res = await api.post('/enviar-sms', {
         numero,
         mensaje
       });


### PR DESCRIPTION
## Summary
- create `AuthContext` with `useAuth` hook to store token and user info
- add axios helper with interceptor for auth token
- add `ProtectedRoute` component
- refactor pages to use new API helper and auth context

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68491290c5e0832097443efcb58887d0