### PR TITLE
Initialize React frontend with Vite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 __pycache__/
 *.pyc
+# Node.js
+frontend/node_modules/
+frontend/dist/

--- a/README.md
+++ b/README.md
@@ -10,3 +10,23 @@ The backend relies on several environment variables:
 - `HABLAME_TOKEN` &ndash; authentication token for the Hablame SMS API.
 
 Make sure these variables are defined before running the application.
+
+## Frontend Development
+
+The `frontend/` directory contains a Vite + React project.
+
+Install dependencies and start the development server:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+To build the production assets:
+
+```bash
+npm run build
+```
+
+The compiled files will appear in `frontend/dist`.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,1 @@
+<!doctype html>\n<html lang="en">\n  <head>\n    <meta charset="UTF-8" />\n    <meta name="viewport" content="width=device-width, initial-scale=1.0" />\n    <title>KIBA</title>\n  </head>\n  <body>\n    <div id="root"></div>\n    <script type="module" src="/src/main.jsx"></script>\n  </body>\n</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "kiba-frontend",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.23.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.0",
+    "autoprefixer": "^10.4.15",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.4.4",
+    "vite": "^5.0.11"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,24 @@
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
+import Layout from './components/Layout'
+import Dashboard from './pages/Dashboard'
+import SendSMS from './pages/SendSMS'
+import ImportSMS from './pages/ImportSMS'
+import Reports from './pages/Reports'
+import Login from './pages/Login'
+
+export default function App() {
+  return (
+    <Router>
+      <Routes>
+        <Route path="/login" element={<Login />} />
+        <Route element={<Layout />}>
+          <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/send-sms" element={<SendSMS />} />
+          <Route path="/import-sms" element={<ImportSMS />} />
+          <Route path="/reports" element={<Reports />} />
+        </Route>
+        <Route path="*" element={<Login />} />
+      </Routes>
+    </Router>
+  )
+}

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,0 +1,20 @@
+import { Link, Outlet } from 'react-router-dom'
+
+export default function Layout() {
+  return (
+    <div>
+      <header className="bg-blue-600 text-white">
+        <nav className="container mx-auto p-4 flex gap-4">
+          <Link to="/dashboard">Dashboard</Link>
+          <Link to="/send-sms">Enviar SMS</Link>
+          <Link to="/import-sms">Importar SMS</Link>
+          <Link to="/reports">Reportes</Link>
+          <Link to="/login" className="ml-auto">Salir</Link>
+        </nav>
+      </header>
+      <main className="p-4">
+        <Outlet />
+      </main>
+    </div>
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    './index.html',
+    './src/**/*.{js,jsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+})


### PR DESCRIPTION
## Summary
- set up React/Vite project under `frontend/`
- configure Tailwind CSS and PostCSS
- add global layout and routing
- document build steps in the README
- ignore frontend build artifacts

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849128e3e6c832097bb34b4df77fc5d