### PR TITLE
Add missing tables to schema.sql

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -29,3 +29,50 @@ CREATE TABLE sms (
     estado VARCHAR(50),
     fecha_envio DATETIME DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE TABLE especialidades (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    nombre VARCHAR(100) NOT NULL UNIQUE
+);
+
+CREATE TABLE pacientes (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    nombre VARCHAR(100) NOT NULL,
+    celular VARCHAR(20) NOT NULL UNIQUE,
+    especialidad_id INT NOT NULL,
+    programada DATETIME,
+    FOREIGN KEY (especialidad_id) REFERENCES especialidades(id),
+    INDEX idx_pacientes_especialidad (especialidad_id)
+);
+
+CREATE TABLE citas (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    paciente_id INT NOT NULL,
+    especialidad_id INT NOT NULL,
+    fecha_hora DATETIME NOT NULL,
+    creado_en DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (paciente_id) REFERENCES pacientes(id),
+    FOREIGN KEY (especialidad_id) REFERENCES especialidades(id),
+    INDEX idx_citas_paciente (paciente_id),
+    INDEX idx_citas_especialidad (especialidad_id)
+);
+
+CREATE TABLE confirmaciones (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    cita_id INT NOT NULL,
+    sms_id INT NOT NULL,
+    confirmada_en DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (cita_id) REFERENCES citas(id),
+    FOREIGN KEY (sms_id) REFERENCES sms(id),
+    INDEX idx_confirmaciones_cita (cita_id),
+    INDEX idx_confirmaciones_sms (sms_id)
+);
+
+CREATE TABLE sms_pendientes (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    celular VARCHAR(20) NOT NULL,
+    mensaje TEXT NOT NULL,
+    especialidad VARCHAR(100),
+    fecha_programada DATETIME,
+    estado VARCHAR(20) DEFAULT 'pendiente'
+);


### PR DESCRIPTION
## Summary
- extend the SQL schema with tables for especialidades, pacientes, citas,
  confirmaciones, and sms_pendientes
- include foreign keys, unique constraints, and indexes matching the models

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6849128cee888320bdb6a21b816a7e6f