### PR TITLE
Refactor dashboard queries to use SQLAlchemy

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from backend.app.config import create_app, db
+from backend.app.routes.sms import sms_bp
+
+@pytest.fixture
+def app():
+    os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+    app = create_app()
+    app.register_blueprint(sms_bp, url_prefix='/api')
+    app.config['TESTING'] = True
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+@pytest.fixture
+def client(app):
+    return app.test_client()

--- a/tests/test_sms_endpoints.py
+++ b/tests/test_sms_endpoints.py
@@ -1,0 +1,43 @@
+from datetime import datetime, timedelta
+from backend.app.config import db
+from backend.app.models.sms import SMS
+
+
+def seed_sms():
+    now = datetime.now().replace(second=0, microsecond=0)
+    yesterday = now - timedelta(days=1)
+    msgs = [
+        SMS(celular="111", mensaje="A", fecha_envio=now, estado="Entregado"),
+        SMS(celular="222", mensaje="B", fecha_envio=now, estado="Entregado"),
+        SMS(celular="333", mensaje="C", fecha_envio=now, estado="Fallido"),
+        SMS(celular="444", mensaje="D", fecha_envio=yesterday, estado="Entregado"),
+    ]
+    db.session.add_all(msgs)
+    db.session.commit()
+
+
+def test_dashboard_counts(client, app):
+    with app.app_context():
+        seed_sms()
+    resp = client.get("/api/dashboard")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["enviados"] == 3
+    assert data["entregados"] == 2
+    assert data["fallidos"] == 1
+    assert len(data["dias"]) == 7
+    assert len(data["cantidades"]) == 7
+    assert data["cantidades"][-1] == 3
+    assert data["cantidades"][-2] == 1
+
+
+def test_historial_response(client, app):
+    with app.app_context():
+        seed_sms()
+    resp = client.get("/api/historial")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data, list)
+    assert len(data) == 4
+    assert data[-1]["numero"] == "444"
+    assert {"fecha_envio", "numero", "mensaje", "estado"} <= data[0].keys()


### PR DESCRIPTION
## Summary
- refactor `/dashboard` to use SQLAlchemy queries instead of raw SQL
- refactor `/historial` to fetch `SMS` objects and serialize them
- add unit tests for both endpoints using a temporary SQLite DB

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6849128b46908320b5632da1f3e078d9