### PR TITLE
Disable table creation route; add CLI commands

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -28,36 +28,15 @@ def home():
     return 'KIBA Backend funcionando correctamente ✅'
 
 #⚠️ Ruta desactivada por seguridad
-@app.route('/crear-tablas')
-def crear_tablas():
-        db.create_all()
-        return '✅ Tablas creadas correctamente en la base de datos.'
+# @app.route('/crear-tablas')
+# def crear_tablas():
+#         db.create_all()
+#         return '✅ Tablas creadas correctamente en la base de datos.'
 
-# ⚠️ Ruta desactivada por seguridad
-# @app.route('/cargar-datos')
-# def cargar_datos():
-#     if not Rol.query.first():
-#         admin_role = Rol(nombre='Administrador')
-#         operator_role = Rol(nombre='Operador')
-#         db.session.add(admin_role)
-#         db.session.add(operator_role)
+# ⚠️ Código para cargar datos de ejemplo disponible como comando CLI en manage.py
 
-#     if not Especialidad.query.first():
-#         especialidades = ['Ortopedia', 'Medicina Interna', 'Pediatría', 'Cardiología']
-#         for esp in especialidades:
-#             nueva = Especialidad(nombre=esp)
-#             db.session.add(nueva)
-
-#     if not Usuario.query.filter_by(correo='admin@kiba.com').first():
-#         admin = Usuario(
-#             correo='admin@kiba.com',
-#             contrasena='admin123',
-#             rol_id=1
-#         )
-#         db.session.add(admin)
-
-#     db.session.commit()
-#     return '✅ Datos iniciales cargados correctamente en la base de datos.'
+import os
 
 if __name__ == '__main__':
-    app.run(debug=True, port=5000)
+    debug_mode = os.environ.get('FLASK_DEBUG', 'False').lower() in ['1', 'true', 't', 'yes']
+    app.run(debug=debug_mode, port=5000)

--- a/manage.py
+++ b/manage.py
@@ -1,6 +1,8 @@
 # KIBA/manage.py
 from backend.app.main import app
 from backend.app.config import db
+from backend.app.models.user import Usuario, Rol
+from backend.app.models.sms import Especialidad
 from flask_migrate import Migrate, MigrateCommand
 from flask_script import Manager
 
@@ -12,6 +14,42 @@ migrate = Migrate(app, db)
 # Configura Manager
 manager = Manager(app)
 manager.add_command('db', MigrateCommand)
+
+
+@manager.command
+def crear_tablas():
+    """Crear tablas de la base de datos."""
+    with app.app_context():
+        db.create_all()
+        print("✅ Tablas creadas correctamente en la base de datos.")
+
+
+@manager.command
+def cargar_datos():
+    """Carga datos de ejemplo en la base de datos."""
+    with app.app_context():
+        if not Rol.query.first():
+            admin_role = Rol(nombre='Administrador')
+            operator_role = Rol(nombre='Operador')
+            db.session.add(admin_role)
+            db.session.add(operator_role)
+
+        if not Especialidad.query.first():
+            especialidades = ['Ortopedia', 'Medicina Interna', 'Pediatría', 'Cardiología']
+            for esp in especialidades:
+                nueva = Especialidad(nombre=esp)
+                db.session.add(nueva)
+
+        if not Usuario.query.filter_by(correo='admin@kiba.com').first():
+            admin = Usuario(
+                correo='admin@kiba.com',
+                contrasena='admin123',
+                rol_id=1
+            )
+            db.session.add(admin)
+
+        db.session.commit()
+        print('✅ Datos iniciales cargados correctamente en la base de datos.')
 
 if __name__ == '__main__':
     manager.run()


### PR DESCRIPTION
## Summary
- comment out the `/crear-tablas` route
- move sample data loader to CLI script
- allow debug mode to be set via `FLASK_DEBUG` environment variable

## Testing
- `python -m py_compile backend/app/main.py manage.py`

------
https://chatgpt.com/codex/tasks/task_e_6849128a6a408320af80664c60b54a50