### PR TITLE
Use Flask secret key for token handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,6 @@ The backend relies on several environment variables:
 - `HABLAME_ACCOUNT` &ndash; account identifier for the Hablame SMS API.
 - `HABLAME_APIKEY` &ndash; API key for the Hablame SMS API.
 - `HABLAME_TOKEN` &ndash; authentication token for the Hablame SMS API.
+- `SECRET_KEY` &ndash; secret used to sign JWTs and Flask sessions. Defaults to `kiba-insecure-secret`.
 
 Make sure these variables are defined before running the application.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -14,7 +14,8 @@ def create_app():
     # Lee la cadena de conexión desde la variable de entorno DATABASE_URL
     app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('DATABASE_URL')
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-    app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'clave-super-secreta-kiba')
+    # SECRET_KEY is used to sign session and JWT tokens
+    app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'kiba-insecure-secret')
 
     db.init_app(app)
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,6 @@
 # backend/app/main.py
 
+import os
 from backend.app.config import create_app, db
 from backend.app.models.user import Usuario, Rol
 from backend.app.models.sms import Especialidad, SMS, Confirmacion
@@ -12,6 +13,9 @@ from flask_migrate import Migrate
 from backend.app.routes.confirmacion import confirmacion_bp
 from backend.app.routes.sms import sms_bp
 
+
+# Ensure SECRET_KEY exists when running the development server directly
+os.environ.setdefault('SECRET_KEY', 'kiba-insecure-secret')
 
 app = create_app()
 app.register_blueprint(auth_bp, url_prefix='/api')

--- a/backend/app/utils/token_manager.py
+++ b/backend/app/utils/token_manager.py
@@ -3,12 +3,10 @@
 import jwt
 import datetime
 from functools import wraps
-from flask import request, jsonify
+from flask import request, jsonify, current_app
 from backend.app.config import db
 from backend.app.models.user import Usuario
 
-# Clave secreta para firmar el Token JWT
-SECRET_KEY = 'clave-super-secreta-kiba'  # (más adelante podemos moverla a .env para producción)
 
 # Función para generar el token
 def generar_token(usuario):
@@ -18,7 +16,8 @@ def generar_token(usuario):
         'rol': usuario.rol.nombre,
         'exp': datetime.datetime.utcnow() + datetime.timedelta(hours=12)  # Válido por 12 horas
     }
-    token = jwt.encode(payload, SECRET_KEY, algorithm='HS256')
+    secret = current_app.config['SECRET_KEY']
+    token = jwt.encode(payload, secret, algorithm='HS256')
     return token
 
 # Decorador para proteger rutas
@@ -34,7 +33,8 @@ def token_requerido(f):
             return jsonify({'error': 'Token de acceso requerido.'}), 401
 
         try:
-            datos = jwt.decode(token, SECRET_KEY, algorithms=['HS256'])
+            secret = current_app.config['SECRET_KEY']
+            datos = jwt.decode(token, secret, algorithms=['HS256'])
             usuario = Usuario.query.get(datos['id'])
             if not usuario:
                 return jsonify({'error': 'Usuario no válido.'}), 401

--- a/manage.py
+++ b/manage.py
@@ -1,4 +1,9 @@
 # KIBA/manage.py
+import os
+
+# Ensure a SECRET_KEY exists for the application
+os.environ.setdefault('SECRET_KEY', 'kiba-insecure-secret')
+
 from backend.app.main import app
 from backend.app.config import db
 from flask_migrate import Migrate, MigrateCommand


### PR DESCRIPTION
## Summary
- remove hard-coded `SECRET_KEY` usage
- derive SECRET_KEY from Flask config
- set SECRET_KEY from environment variable in `config.py`
- ensure development scripts fall back to default SECRET_KEY
- document new `SECRET_KEY` env variable

## Testing
- `python -m py_compile backend/app/utils/token_manager.py backend/app/config.py backend/app/main.py manage.py`

------
https://chatgpt.com/codex/tasks/task_e_684912892244832083fea5280aee8cc1