### PR TITLE
Remove duplicate Confirmacion model

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,8 @@
 
 from backend.app.config import create_app, db
 from backend.app.models.user import Usuario, Rol
-from backend.app.models.sms import Especialidad, SMS, Confirmacion
+from backend.app.models.sms import Especialidad, SMS
+from backend.app.models.confirmacion import Confirmacion
 from backend.app.routes.auth import auth_bp
 from backend.app.models.sms_pendiente import SMSPendiente
 from backend.app.routes.specialty import specialty_bp

--- a/backend/app/models/sms.py
+++ b/backend/app/models/sms.py
@@ -28,17 +28,3 @@ class SMS(db.Model):
         return f'<SMS {self.celular}>'
 
 
-class Confirmacion(db.Model):
-    __tablename__ = 'confirmaciones'
-
-    id = db.Column(db.Integer, primary_key=True)
-    cita_id = db.Column(db.Integer, db.ForeignKey('citas.id'), nullable=False)
-    sms_id = db.Column(db.Integer, db.ForeignKey('sms.id'), nullable=False)
-    confirmada_en = db.Column(db.DateTime, default=datetime.utcnow)
-
-    sms = db.relationship('SMS', backref='confirmaciones')
-    cita = db.relationship('Cita', backref='confirmacion')
-
-    def __repr__(self):
-        return f'<Confirmacion ID {self.id}>'
-

--- a/backend/app/routes/cita.py
+++ b/backend/app/routes/cita.py
@@ -7,7 +7,7 @@ from backend.app.models.paciente import Paciente
 from backend.app.models.sms import Especialidad
 from backend.app.utils.token_manager import token_requerido
 from datetime import datetime
-from backend.app.models.sms import Confirmacion
+from backend.app.models.confirmacion import Confirmacion
 
 
 cita_bp = Blueprint('cita', __name__)

--- a/backend/app/routes/sms.py
+++ b/backend/app/routes/sms.py
@@ -7,7 +7,8 @@ import os
 from datetime import datetime, timedelta
 from sqlalchemy import func
 from backend.app.config import db
-from backend.app.models.sms import Especialidad, SMS, Confirmacion
+from backend.app.models.sms import Especialidad, SMS
+from backend.app.models.confirmacion import Confirmacion
 from backend.app.models.user import Usuario  # Si deseas asociar con usuario
 
 sms_bp = Blueprint('sms', __name__)


### PR DESCRIPTION
## Summary
- keep `Confirmacion` only in `confirmacion.py`
- remove class from `sms.py`
- update imports to use `backend.app.models.confirmacion`
- attempt DB migration

## Testing
- `python manage.py db upgrade` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6849128620548320b73d8d6f6aa5ddc3