### PR TITLE
Add backend development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,23 @@ The backend relies on several environment variables:
 
 Make sure these variables are defined before running the application.
 
+## Backend Development
+
+Install Python dependencies for the backend:
+
+```bash
+pip install -r requirements.txt
+```
+
+Set the required environment variables (`DATABASE_URL`, `SECRET_KEY`, etc.) and
+start the development server:
+
+```bash
+python manage.py runserver
+```
+
+The API will be available at `http://localhost:5000/` by default.
+
 ## Frontend Development
 
 The `frontend/` directory contains a Vite + React project.


### PR DESCRIPTION
## Summary
- document how to setup backend development

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684a4ad8542c83209b1655c52dd5d0a8