### PR TITLE
Add auth endpoint tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,22 +2,26 @@ import os
 import sys
 import pytest
 
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from backend.app.config import create_app, db
 from backend.app.routes.sms import sms_bp
+from backend.app.routes.auth import auth_bp
+
 
 @pytest.fixture
 def app():
-    os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+    os.environ["DATABASE_URL"] = "sqlite:///:memory:"
     app = create_app()
-    app.register_blueprint(sms_bp, url_prefix='/api')
-    app.config['TESTING'] = True
+    app.register_blueprint(sms_bp, url_prefix="/api")
+    app.register_blueprint(auth_bp, url_prefix="/api")
+    app.config["TESTING"] = True
     with app.app_context():
         db.create_all()
         yield app
         db.session.remove()
         db.drop_all()
+
 
 @pytest.fixture
 def client(app):

--- a/tests/test_auth_endpoints.py
+++ b/tests/test_auth_endpoints.py
@@ -1,0 +1,43 @@
+from backend.app.config import db
+from backend.app.models.user import Rol, Usuario
+
+
+def seed_user():
+    admin_role = Rol(nombre="Administrador")
+    operator_role = Rol(nombre="Operador")
+    db.session.add_all([admin_role, operator_role])
+    user = Usuario(correo="user@example.com", rol=admin_role)
+    user.set_contrasena("secret123")
+    db.session.add(user)
+    db.session.commit()
+
+
+def test_login_success(client, app):
+    with app.app_context():
+        seed_user()
+    resp = client.post(
+        "/api/login",
+        json={"correo": "user@example.com", "contrasena": "secret123"},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "token" in data
+    assert data["rol"] == "Administrador"
+
+
+def test_login_invalid_password(client, app):
+    with app.app_context():
+        seed_user()
+    resp = client.post(
+        "/api/login",
+        json={"correo": "user@example.com", "contrasena": "wrong"},
+    )
+    assert resp.status_code == 401
+
+
+def test_login_unknown_user(client):
+    resp = client.post(
+        "/api/login",
+        json={"correo": "nobody@example.com", "contrasena": "whatever"},
+    )
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- register auth blueprint in test fixture
- add tests for login success and error cases

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684a4ae9e76c8320b36138f6bc94ed39