### PR TITLE
Add JWT protection to SMS routes

### DIFF
--- a/backend/app/routes/sms.py
+++ b/backend/app/routes/sms.py
@@ -10,6 +10,7 @@ from backend.app.config import db
 from backend.app.models.sms import Especialidad, SMS
 from backend.app.models.confirmacion import Confirmacion
 from backend.app.models.user import Usuario  # Si deseas asociar con usuario
+from backend.app.utils.token_manager import token_requerido
 
 sms_bp = Blueprint('sms', __name__)
 
@@ -30,6 +31,7 @@ def obtener_headers():
 # ========================
 
 @sms_bp.route('/enviar-sms', methods=['POST'])
+@token_requerido
 def enviar_sms():
     data = request.get_json()
     numero = data.get('numero')
@@ -64,6 +66,7 @@ def enviar_sms():
 # ========================
 
 @sms_bp.route('/importar-sms', methods=['POST'])
+@token_requerido
 def importar_sms():
     data = request.get_json()
     mensajes = data.get('mensajes')
@@ -94,6 +97,7 @@ def importar_sms():
 # ========================
 
 @sms_bp.route('/dashboard', methods=['GET'])
+@token_requerido
 def dashboard():
     hoy = datetime.now().date()
 
@@ -132,6 +136,7 @@ def dashboard():
 # ========================
 
 @sms_bp.route('/historial', methods=['GET'])
+@token_requerido
 def historial_sms():
     mensajes = db.session.query(SMS).order_by(SMS.fecha_envio.desc()).all()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,8 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from backend.app.config import create_app, db
 from backend.app.routes.sms import sms_bp
+from backend.app.models.user import Usuario, Rol
+from backend.app.utils.token_manager import generar_token
 
 @pytest.fixture
 def app():
@@ -15,6 +17,13 @@ def app():
     app.config['TESTING'] = True
     with app.app_context():
         db.create_all()
+        # seed a default user for auth tests
+        admin_role = Rol(nombre='Test')
+        db.session.add(admin_role)
+        user = Usuario(correo='test@example.com', rol=admin_role)
+        user.set_contrasena('password')
+        db.session.add(user)
+        db.session.commit()
         yield app
         db.session.remove()
         db.drop_all()
@@ -22,3 +31,11 @@ def app():
 @pytest.fixture
 def client(app):
     return app.test_client()
+
+
+@pytest.fixture
+def auth_headers(app):
+    with app.app_context():
+        user = Usuario.query.first()
+        token = generar_token(user)
+    return {'Authorization': token}

--- a/tests/test_sms_endpoints.py
+++ b/tests/test_sms_endpoints.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from unittest.mock import patch
 from backend.app.config import db
 from backend.app.models.sms import SMS
 
@@ -16,10 +17,10 @@ def seed_sms():
     db.session.commit()
 
 
-def test_dashboard_counts(client, app):
+def test_dashboard_counts(client, app, auth_headers):
     with app.app_context():
         seed_sms()
-    resp = client.get("/api/dashboard")
+    resp = client.get("/api/dashboard", headers=auth_headers)
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["enviados"] == 3
@@ -31,13 +32,55 @@ def test_dashboard_counts(client, app):
     assert data["cantidades"][-2] == 1
 
 
-def test_historial_response(client, app):
+def test_historial_response(client, app, auth_headers):
     with app.app_context():
         seed_sms()
-    resp = client.get("/api/historial")
+    resp = client.get("/api/historial", headers=auth_headers)
     assert resp.status_code == 200
     data = resp.get_json()
     assert isinstance(data, list)
     assert len(data) == 4
     assert data[-1]["numero"] == "444"
     assert {"fecha_envio", "numero", "mensaje", "estado"} <= data[0].keys()
+
+
+def test_dashboard_requires_token(client):
+    resp = client.get("/api/dashboard")
+    assert resp.status_code == 401
+
+
+def test_historial_requires_token(client):
+    resp = client.get("/api/historial")
+    assert resp.status_code == 401
+
+
+def test_enviar_sms_requires_token(client):
+    resp = client.post("/api/enviar-sms", json={"numero": "1", "mensaje": "hi"})
+    assert resp.status_code == 401
+
+
+def test_importar_sms_requires_token(client):
+    resp = client.post("/api/importar-sms", json={"mensajes": []})
+    assert resp.status_code == 401
+
+
+def test_enviar_sms_success(client, auth_headers):
+    with patch("backend.app.routes.sms.requests.post") as mock_post:
+        mock_post.return_value.status_code = 200
+        resp = client.post(
+            "/api/enviar-sms",
+            json={"numero": "123", "mensaje": "hola"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+
+
+def test_importar_sms_success(client, auth_headers):
+    with patch("backend.app.routes.sms.requests.post") as mock_post:
+        mock_post.return_value.status_code = 200
+        resp = client.post(
+            "/api/importar-sms",
+            json={"mensajes": [{"numero": "1", "mensaje": "a"}]},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- secure SMS endpoints with `token_requerido`
- seed a default user in tests and provide an auth header fixture
- adjust SMS endpoint tests to send JWTs
- verify that routes return 401 without a token and succeed with a token

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684a4ae86f808320b258f90387200046