### PR TITLE
Fix token header and add auth test

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -7,7 +7,8 @@ const api = axios.create({
 api.interceptors.request.use((config) => {
   const token = localStorage.getItem('token');
   if (token) {
-    config.headers.Authorization = `Bearer ${token}`;
+    // Send the raw JWT token without the usual "Bearer" prefix.
+    config.headers.Authorization = token;
   }
   return config;
 });

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,12 +6,14 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from backend.app.config import create_app, db
 from backend.app.routes.sms import sms_bp
+from backend.app.routes.auth import auth_bp
 
 @pytest.fixture
 def app():
     os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
     app = create_app()
     app.register_blueprint(sms_bp, url_prefix='/api')
+    app.register_blueprint(auth_bp, url_prefix='/api')
     app.config['TESTING'] = True
     with app.app_context():
         db.create_all()

--- a/tests/test_auth_token.py
+++ b/tests/test_auth_token.py
@@ -1,0 +1,29 @@
+from backend.app.config import db
+from backend.app.models.user import Usuario, Rol
+
+
+def seed_user():
+    admin_role = Rol(id=1, nombre="Administrador")
+    db.session.add(admin_role)
+    user = Usuario(correo="admin@example.com", rol_id=1)
+    user.set_contrasena("secret")
+    db.session.add(user)
+    db.session.commit()
+
+
+def test_login_and_profile(client, app):
+    with app.app_context():
+        seed_user()
+    # Login to obtain JWT token
+    resp = client.post(
+        "/api/login",
+        json={"correo": "admin@example.com", "contrasena": "secret"},
+    )
+    assert resp.status_code == 200
+    token = resp.get_json()["token"]
+
+    # Access protected endpoint using raw token header
+    resp2 = client.get("/api/perfil", headers={"Authorization": token})
+    assert resp2.status_code == 200
+    data = resp2.get_json()
+    assert data["correo"] == "admin@example.com"


### PR DESCRIPTION
## Summary
- send raw JWT in frontend API requests
- expose auth routes in tests
- add regression test for token-protected endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684a4ae6f7d88320b7ab2dcaada54a8c