### PR TITLE
Add environment example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Copy this file to `.env` and fill in the values.
+# The `.env` file is ignored by Git.
+DATABASE_URL=
+HABLAME_ACCOUNT=
+HABLAME_APIKEY=
+HABLAME_TOKEN=
+SECRET_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ __pycache__/
 # Node.js
 frontend/node_modules/
 frontend/dist/
+
+# Local environment
+.env


### PR DESCRIPTION
## Summary
- add a `.env.example` template showing required variables
- ignore the real `.env` file in `.gitignore`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684a4adbb01483208928b00345360e46