### PR TITLE
Add backend requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Make sure these variables are defined before running the application.
 
 ## Backend Development
 
-Install Python dependencies for the backend:
+Install the Python dependencies used by the backend (Flask, Flask-SQLAlchemy,
+Flask-Migrate, etc.) using `requirements.txt`:
 
 ```bash
 pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+Flask
+Flask-Cors
+Flask-SQLAlchemy
+Flask-Migrate
+Flask-Script
+PyJWT
+bcrypt
+requests
+pytest


### PR DESCRIPTION
## Summary
- add `requirements.txt` with all backend dependencies
- mention that dependencies like Flask and Flask-Migrate are installed from this file in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684a547358f88320bd46c73b8cabb3e8