### PR TITLE
Protect sms endpoints with JWT

### DIFF
--- a/backend/app/routes/sms.py
+++ b/backend/app/routes/sms.py
@@ -10,6 +10,7 @@ from backend.app.config import db
 from backend.app.models.sms import Especialidad, SMS
 from backend.app.models.confirmacion import Confirmacion
 from backend.app.models.user import Usuario  # Si deseas asociar con usuario
+from backend.app.utils.token_manager import token_requerido
 
 sms_bp = Blueprint('sms', __name__)
 
@@ -30,6 +31,7 @@ def obtener_headers():
 # ========================
 
 @sms_bp.route('/enviar-sms', methods=['POST'])
+@token_requerido
 def enviar_sms():
     data = request.get_json()
     numero = data.get('numero')
@@ -64,6 +66,7 @@ def enviar_sms():
 # ========================
 
 @sms_bp.route('/importar-sms', methods=['POST'])
+@token_requerido
 def importar_sms():
     data = request.get_json()
     mensajes = data.get('mensajes')
@@ -94,6 +97,7 @@ def importar_sms():
 # ========================
 
 @sms_bp.route('/dashboard', methods=['GET'])
+@token_requerido
 def dashboard():
     hoy = datetime.now().date()
 
@@ -132,6 +136,7 @@ def dashboard():
 # ========================
 
 @sms_bp.route('/historial', methods=['GET'])
+@token_requerido
 def historial_sms():
     mensajes = db.session.query(SMS).order_by(SMS.fecha_envio.desc()).all()
 

--- a/tests/test_sms_endpoints.py
+++ b/tests/test_sms_endpoints.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 from backend.app.config import db
 from backend.app.models.sms import SMS
+from backend.app.models.user import Rol, Usuario
 
 
 def seed_sms():
@@ -16,10 +17,31 @@ def seed_sms():
     db.session.commit()
 
 
+def seed_user():
+    admin_role = Rol(nombre="Administrador")
+    operator_role = Rol(nombre="Operador")
+    db.session.add_all([admin_role, operator_role])
+    user = Usuario(correo="user@example.com", rol=admin_role)
+    user.set_contrasena("secret123")
+    db.session.add(user)
+    db.session.commit()
+
+
+def get_token(client, app):
+    with app.app_context():
+        seed_user()
+    resp = client.post(
+        "/api/login",
+        json={"correo": "user@example.com", "contrasena": "secret123"},
+    )
+    return resp.get_json()["token"]
+
+
 def test_dashboard_counts(client, app):
+    token = get_token(client, app)
     with app.app_context():
         seed_sms()
-    resp = client.get("/api/dashboard")
+    resp = client.get("/api/dashboard", headers={"Authorization": token})
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["enviados"] == 3
@@ -32,12 +54,78 @@ def test_dashboard_counts(client, app):
 
 
 def test_historial_response(client, app):
+    token = get_token(client, app)
     with app.app_context():
         seed_sms()
-    resp = client.get("/api/historial")
+    resp = client.get("/api/historial", headers={"Authorization": token})
     assert resp.status_code == 200
     data = resp.get_json()
     assert isinstance(data, list)
     assert len(data) == 4
     assert data[-1]["numero"] == "444"
     assert {"fecha_envio", "numero", "mensaje", "estado"} <= data[0].keys()
+
+
+def test_dashboard_requires_token(client, app):
+    with app.app_context():
+        seed_sms()
+    resp = client.get("/api/dashboard")
+    assert resp.status_code == 401
+
+
+def test_historial_requires_token(client, app):
+    with app.app_context():
+        seed_sms()
+    resp = client.get("/api/historial")
+    assert resp.status_code == 401
+
+
+def test_enviar_sms_requires_token(client):
+    resp = client.post("/api/enviar-sms", json={"numero": "1", "mensaje": "hi"})
+    assert resp.status_code == 401
+
+
+def test_importar_sms_requires_token(client):
+    resp = client.post(
+        "/api/importar-sms",
+        json={"mensajes": [{"numero": "1", "mensaje": "hi"}]},
+    )
+    assert resp.status_code == 401
+
+
+def test_enviar_sms_with_token(client, app, monkeypatch):
+    token = get_token(client, app)
+
+    def mock_post(url, headers=None, data=None):
+        class R:
+            status_code = 200
+            text = ""
+
+        return R()
+
+    monkeypatch.setattr("backend.app.routes.sms.requests.post", mock_post)
+    resp = client.post(
+        "/api/enviar-sms",
+        json={"numero": "1", "mensaje": "hi"},
+        headers={"Authorization": token},
+    )
+    assert resp.status_code == 200
+
+
+def test_importar_sms_with_token(client, app, monkeypatch):
+    token = get_token(client, app)
+
+    def mock_post(url, headers=None, data=None):
+        class R:
+            status_code = 200
+            text = ""
+
+        return R()
+
+    monkeypatch.setattr("backend.app.routes.sms.requests.post", mock_post)
+    resp = client.post(
+        "/api/importar-sms",
+        json={"mensajes": [{"numero": "1", "mensaje": "hi"}]},
+        headers={"Authorization": token},
+    )
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- secure sms routes with `token_requerido`
- test sms routes for JWT authentication

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684a5478340883208fea8c75a4082dc4