### PR TITLE
Fix Bearer token support

### DIFF
--- a/backend/app/utils/token_manager.py
+++ b/backend/app/utils/token_manager.py
@@ -28,6 +28,8 @@ def token_requerido(f):
 
         if 'Authorization' in request.headers:
             token = request.headers['Authorization']
+            if token.startswith('Bearer '):
+                token = token[len('Bearer '):]
 
         if not token:
             return jsonify({'error': 'Token de acceso requerido.'}), 401

--- a/tests/test_auth_endpoints.py
+++ b/tests/test_auth_endpoints.py
@@ -41,3 +41,15 @@ def test_login_unknown_user(client):
         json={"correo": "nobody@example.com", "contrasena": "whatever"},
     )
     assert resp.status_code == 404
+
+
+def test_authenticated_profile(client, app):
+    with app.app_context():
+        seed_user()
+    login_resp = client.post(
+        "/api/login",
+        json={"correo": "user@example.com", "contrasena": "secret123"},
+    )
+    token = login_resp.get_json()["token"]
+    resp = client.get("/api/perfil", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- allow `Bearer` prefix in `Authorization` header
- test accessing /api/perfil with a Bearer token

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684a5479bfbc83209b6fca9b433ed9a9