### PR TITLE
Add auth protection for confirmaciones route

### DIFF
--- a/backend/app/routes/confirmacion.py
+++ b/backend/app/routes/confirmacion.py
@@ -6,11 +6,13 @@ from backend.app.models.sms import SMS
 from backend.app.models.cita import Cita
 from backend.app.models.paciente import Paciente
 from backend.app.models.sms import Especialidad
+from backend.app.utils.token_manager import token_requerido
 from datetime import datetime
 
 confirmacion_bp = Blueprint('confirmacion', __name__)
 
 @confirmacion_bp.route('/confirmaciones', methods=['GET'])
+@token_requerido
 def obtener_confirmaciones():
     fecha_filtro = request.args.get('fecha')  # Formato esperado: YYYY-MM-DD
     paciente_id = request.args.get('paciente_id')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from backend.app.config import create_app, db
 from backend.app.routes.sms import sms_bp
 from backend.app.routes.auth import auth_bp
+from backend.app.routes.confirmacion import confirmacion_bp
 
 
 @pytest.fixture
@@ -15,6 +16,7 @@ def app():
     app = create_app()
     app.register_blueprint(sms_bp, url_prefix="/api")
     app.register_blueprint(auth_bp, url_prefix="/api")
+    app.register_blueprint(confirmacion_bp, url_prefix="/api")
     app.config["TESTING"] = True
     with app.app_context():
         db.create_all()

--- a/tests/test_confirmacion_endpoints.py
+++ b/tests/test_confirmacion_endpoints.py
@@ -1,0 +1,33 @@
+from backend.app.config import db
+from backend.app.models.user import Rol, Usuario
+
+
+def seed_user():
+    admin_role = Rol(nombre="Administrador")
+    operator_role = Rol(nombre="Operador")
+    db.session.add_all([admin_role, operator_role])
+    user = Usuario(correo="user@example.com", rol=admin_role)
+    user.set_contrasena("secret123")
+    db.session.add(user)
+    db.session.commit()
+
+
+def get_token(client, app):
+    with app.app_context():
+        seed_user()
+    resp = client.post(
+        "/api/login",
+        json={"correo": "user@example.com", "contrasena": "secret123"},
+    )
+    return resp.get_json()["token"]
+
+
+def test_confirmaciones_requires_token(client):
+    resp = client.get("/api/confirmaciones")
+    assert resp.status_code == 401
+
+
+def test_confirmaciones_with_token(client, app):
+    token = get_token(client, app)
+    resp = client.get("/api/confirmaciones", headers={"Authorization": token})
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- secure `/confirmaciones` with `@token_requerido`
- register confirmaciones blueprint in tests
- add tests to verify token requirement

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684ae3284a1483209db73743037ba76c