### PR TITLE
Remove unused db import

### DIFF
--- a/backend/app/utils/token_manager.py
+++ b/backend/app/utils/token_manager.py
@@ -4,7 +4,6 @@ import jwt
 import datetime
 from functools import wraps
 from flask import request, jsonify, current_app
-from backend.app.config import db
 from backend.app.models.user import Usuario
 
 


### PR DESCRIPTION
## Summary
- remove unused `db` import from token manager

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684ae32ed6dc8320b3001c9aedffad15