### PR TITLE
Add SQLite fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The backend relies on several environment variables:
 
-- `DATABASE_URL` &ndash; SQLAlchemy connection string for the application's database.
+- `DATABASE_URL` &ndash; SQLAlchemy connection string for the application's database. If not set, the backend uses a local SQLite file `sqlite:///kiba.db`.
 - `HABLAME_ACCOUNT` &ndash; account identifier for the Hablame SMS API.
 - `HABLAME_APIKEY` &ndash; API key for the Hablame SMS API.
 - `HABLAME_TOKEN` &ndash; authentication token for the Hablame SMS API.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -11,8 +11,10 @@ def create_app():
     app = Flask(__name__)
     CORS(app)
 
-    # Lee la cadena de conexión desde la variable de entorno DATABASE_URL
-    app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('DATABASE_URL')
+    # Use DATABASE_URL if defined, otherwise fall back to a local SQLite file
+    app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get(
+        'DATABASE_URL', 'sqlite:///kiba.db'
+    )
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
     # SECRET_KEY is used to sign session and JWT tokens
     app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'kiba-insecure-secret')


### PR DESCRIPTION
## Summary
- default SQLALCHEMY_DATABASE_URI to `sqlite:///kiba.db` when `DATABASE_URL` isn't set
- document the new fallback in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684ae3303bf8832082c240fbb6892aab