### PR TITLE
Add Docker support for backend and compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+frontend/node_modules
+frontend/dist
+__pycache__/
+*.pyc
+*.zip
+tests/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+EXPOSE 5000
+CMD ["python", "manage.py", "runserver", "--host", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -49,3 +49,27 @@ npm run build
 ```
 
 The compiled files will appear in `frontend/dist`.
+
+## Docker Usage
+
+A `Dockerfile` is provided for the backend. Build the image with:
+
+```bash
+docker build -t kiba-backend .
+```
+
+Run the container exposing port `5000`:
+
+```bash
+docker run -p 5000:5000 kiba-backend
+```
+
+The repository also includes a `docker-compose.yml` to run both the backend and
+the React frontend:
+
+```bash
+docker-compose up --build
+```
+
+The API will be available at `http://localhost:5000/` and the frontend at
+`http://localhost:5173/`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+services:
+  backend:
+    build: .
+    ports:
+      - "5000:5000"
+    environment:
+      - DATABASE_URL=sqlite:///database/app.db
+      - SECRET_KEY=kiba-insecure-secret
+  frontend:
+    build: ./frontend
+    working_dir: /app
+    command: npm run dev -- --host
+    ports:
+      - "5173:5173"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+EXPOSE 5173
+CMD ["npm", "run", "dev", "--", "--host"]


### PR DESCRIPTION
## Summary
- add Dockerfile to run backend
- include frontend image and compose file
- document Docker usage in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684ae3353c7083209ee2ebe2abeda395