### PR TITLE
Add example environment file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+DATABASE_URL=postgresql://user:password@localhost/dbname
+HABLAME_ACCOUNT=your-hablame-account
+HABLAME_APIKEY=your-hablame-apikey
+HABLAME_TOKEN=your-hablame-token
+SECRET_KEY=change-me

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ The backend relies on several environment variables:
 - `HABLAME_TOKEN` &ndash; authentication token for the Hablame SMS API.
 - `SECRET_KEY` &ndash; secret used to sign JWTs and Flask sessions. Defaults to `kiba-insecure-secret`.
 
-Make sure these variables are defined before running the application.
+A `.env.example` file contains these variables with placeholder values. Copy it to
+`.env` and edit it with your credentials. Make sure the variables are loaded
+before running the application.
 
 ## Backend Development
 
@@ -21,8 +23,7 @@ Flask-Migrate, etc.) using `requirements.txt`:
 pip install -r requirements.txt
 ```
 
-Set the required environment variables (`DATABASE_URL`, `SECRET_KEY`, etc.) and
-start the development server:
+Ensure the variables from your `.env` file are loaded and start the development server:
 
 ```bash
 python manage.py runserver


### PR DESCRIPTION
## Summary
- provide a `.env.example` template listing required environment variables
- reference the new `.env.example` in the README for easier setup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684ae339df4c8320b37732864d708a99