### PR TITLE
Add Docker deployment files and env support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
-DATABASE_URL=postgresql://user:password@localhost/dbname
-HABLAME_ACCOUNT=your-hablame-account
-HABLAME_APIKEY=your-hablame-apikey
-HABLAME_TOKEN=your-hablame-token
-SECRET_KEY=change-me
+DATABASE_URL=postgresql://user:password@db:5432/kiba
+JWT_SECRET=una_clave_secreta_segura
+API_HABLAME_KEY=clave_real_o_ficticia
+FRONTEND_URL=http://localhost:3000
+BACKEND_URL=http://localhost:5000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
-FROM python:3.10-slim
+FROM python:3.11-slim
 WORKDIR /app
-COPY requirements.txt .
+COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
-COPY . .
+COPY backend ./backend
+COPY manage.py ./
+ENV PYTHONUNBUFFERED=1
 EXPOSE 5000
-CMD ["python", "manage.py", "runserver", "--host", "0.0.0.0"]
+CMD ["gunicorn", "-b", "0.0.0.0:5000", "backend.app.main:app"]

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 The backend relies on several environment variables:
 
-- `DATABASE_URL` &ndash; SQLAlchemy connection string for the application's database. If not set, the backend uses a local SQLite file `sqlite:///kiba.db`.
-- `HABLAME_ACCOUNT` &ndash; account identifier for the Hablame SMS API.
-- `HABLAME_APIKEY` &ndash; API key for the Hablame SMS API.
-- `HABLAME_TOKEN` &ndash; authentication token for the Hablame SMS API.
-- `SECRET_KEY` &ndash; secret used to sign JWTs and Flask sessions. Defaults to `kiba-insecure-secret`.
+- `DATABASE_URL` &ndash; SQLAlchemy connection string for the application's database.
+- `JWT_SECRET` &ndash; secret used to sign JWTs and Flask sessions.
+- `API_HABLAME_KEY` &ndash; API key for the Hablame SMS API (real or dummy).
+- `FRONTEND_URL` &ndash; URL where the React frontend is served.
+- `BACKEND_URL` &ndash; base URL for the Flask API.
 
 A `.env.example` file contains these variables with placeholder values. Copy it to
 `.env` and edit it with your credentials. Make sure the variables are loaded
@@ -51,6 +51,9 @@ npm run build
 
 The compiled files will appear in `frontend/dist`.
 
+When deploying the React application to Vercel, set `VITE_API_URL` in the
+project settings so that the frontend knows where to reach the backend API.
+
 ## Docker Usage
 
 A `Dockerfile` is provided for the backend. Build the image with:
@@ -73,4 +76,4 @@ docker-compose up --build
 ```
 
 The API will be available at `http://localhost:5000/` and the frontend at
-`http://localhost:5173/`.
+`http://localhost:3000/`.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -2,22 +2,17 @@
 
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
-from flask_cors import CORS
 import os
 
 db = SQLAlchemy()
 
 def create_app():
     app = Flask(__name__)
-    CORS(app)
-
-    # Use DATABASE_URL if defined, otherwise fall back to a local SQLite file
-    app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get(
-        'DATABASE_URL', 'sqlite:///kiba.db'
-    )
+    # Database connection string
+    app.config['SQLALCHEMY_DATABASE_URI'] = os.environ['DATABASE_URL']
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-    # SECRET_KEY is used to sign session and JWT tokens
-    app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'kiba-insecure-secret')
+    # Secret used to sign JWTs and sessions
+    app.config['SECRET_KEY'] = os.environ['JWT_SECRET']
 
     db.init_app(app)
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,8 @@
 # backend/app/main.py
 
 import os
+from dotenv import load_dotenv
+from flask_cors import CORS
 from backend.app.config import create_app, db
 from backend.app.models.user import Usuario, Rol
 from backend.app.models.sms import Especialidad, SMS
@@ -14,11 +16,10 @@ from flask_migrate import Migrate
 from backend.app.routes.confirmacion import confirmacion_bp
 from backend.app.routes.sms import sms_bp
 
-
-# Ensure SECRET_KEY exists when running the development server directly
-os.environ.setdefault('SECRET_KEY', 'kiba-insecure-secret')
+load_dotenv()
 
 app = create_app()
+CORS(app, origins=os.getenv('FRONTEND_URL'))
 app.register_blueprint(auth_bp, url_prefix='/api')
 app.register_blueprint(specialty_bp, url_prefix='/api')
 app.register_blueprint(paciente_bp, url_prefix='/api')
@@ -40,8 +41,6 @@ def home():
 
 # ⚠️ Código para cargar datos de ejemplo disponible como comando CLI en manage.py
 
-import os
-
 if __name__ == '__main__':
     debug_mode = os.environ.get('FLASK_DEBUG', 'False').lower() in ['1', 'true', 't', 'yes']
-    app.run(debug=debug_mode, port=5000)
+    app.run(host='0.0.0.0', debug=debug_mode, port=5000)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,42 @@
 version: '3.8'
 services:
+  db:
+    image: postgres:15
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: kiba
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    networks:
+      - kiba
+
   backend:
     build: .
+    depends_on:
+      - db
+    env_file: .env
     ports:
       - "5000:5000"
-    environment:
-      - DATABASE_URL=sqlite:///database/app.db
-      - SECRET_KEY=kiba-insecure-secret
+    restart: unless-stopped
+    networks:
+      - kiba
+
   frontend:
     build: ./frontend
-    working_dir: /app
-    command: npm run dev -- --host
+    command: npm run dev -- --host --port 3000
+    env_file: .env
     ports:
-      - "5173:5173"
+      - "3000:3000"
+    restart: unless-stopped
+    networks:
+      - kiba
+    # This service is optional if the frontend is deployed separately (e.g. Vercel)
+
+volumes:
+  pgdata:
+
+networks:
+  kiba:
+    driver: bridge

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,5 +3,5 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm install
 COPY . .
-EXPOSE 5173
-CMD ["npm", "run", "dev", "--", "--host"]
+EXPOSE 3000
+CMD ["npm", "run", "dev", "--", "--host", "--port", "3000"]

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const api = axios.create({
-  baseURL: 'http://localhost:5000/api'
+  baseURL: `${import.meta.env.VITE_API_URL}/api`
 });
 
 api.interceptors.request.use((config) => {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,6 +1,18 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 
-export default defineConfig({
-  plugins: [react()],
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  return {
+    plugins: [react()],
+    server: {
+      port: 3000,
+      proxy: {
+        '/api': {
+          target: env.VITE_API_URL || 'http://localhost:5000',
+          changeOrigin: true
+        }
+      }
+    }
+  }
 })

--- a/manage.py
+++ b/manage.py
@@ -1,8 +1,8 @@
 # KIBA/manage.py
 import os
+from dotenv import load_dotenv
 
-# Ensure a SECRET_KEY exists for the application
-os.environ.setdefault('SECRET_KEY', 'kiba-insecure-secret')
+load_dotenv()
 
 from backend.app.main import app
 from backend.app.config import db


### PR DESCRIPTION
## Summary
- update environment variable list
- add docker compose with backend, frontend and database
- load env vars and configure CORS in backend
- expose backend via gunicorn
- use VITE_API_URL in React client and configure proxy
- expose frontend on port 3000

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684ba442ce5c8320886e33b4a0574a9a