### PR TITLE
Document new Hablame variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,8 @@
 DATABASE_URL=postgresql://user:password@db:5432/kiba
 JWT_SECRET=una_clave_secreta_segura
-API_HABLAME_KEY=clave_real_o_ficticia
+HABLAME_ACCOUNT=cuenta_hablame
+HABLAME_APIKEY=apikey_hablame
+HABLAME_TOKEN=token_hablame
+# API_HABLAME_KEY=clave_real_o_ficticia  # unused
 FRONTEND_URL=http://localhost:3000
-BACKEND_URL=http://localhost:5000
+# BACKEND_URL=http://localhost:5000  # unused

--- a/README.md
+++ b/README.md
@@ -6,13 +6,17 @@ The backend relies on several environment variables:
 
 - `DATABASE_URL` &ndash; SQLAlchemy connection string for the application's database.
 - `JWT_SECRET` &ndash; secret used to sign JWTs and Flask sessions.
-- `API_HABLAME_KEY` &ndash; API key for the Hablame SMS API (real or dummy).
+- `HABLAME_ACCOUNT` &ndash; account identifier for the Hablame SMS API.
+- `HABLAME_APIKEY` &ndash; API key for the Hablame SMS API.
+- `HABLAME_TOKEN` &ndash; token for the Hablame SMS API.
 - `FRONTEND_URL` &ndash; URL where the React frontend is served.
-- `BACKEND_URL` &ndash; base URL for the Flask API.
+- `API_HABLAME_KEY` &ndash; legacy key, currently unused.
+- `BACKEND_URL` &ndash; unused base URL variable.
 
 A `.env.example` file contains these variables with placeholder values. Copy it to
-`.env` and edit it with your credentials. Make sure the variables are loaded
-before running the application.
+`.env` and edit it with your credentials. Ensure the variables are loaded
+before running the application. When deploying on **Render**, add the same
+variables in the dashboard so that the container starts correctly.
 
 ## Backend Development
 


### PR DESCRIPTION
## Summary
- document `HABLAME_ACCOUNT`, `HABLAME_APIKEY` and `HABLAME_TOKEN`
- note legacy variables in README
- mention Render deployment requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684c8665ba148320adcc45befd75d8d8