### PR TITLE
Fix KeyError in tests by setting JWT_SECRET

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ from backend.app.routes.confirmacion import confirmacion_bp
 @pytest.fixture
 def app():
     os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+    os.environ["JWT_SECRET"] = "testsecret"
     app = create_app()
     app.register_blueprint(sms_bp, url_prefix="/api")
     app.register_blueprint(auth_bp, url_prefix="/api")


### PR DESCRIPTION
## Summary
- set a default `JWT_SECRET` in `tests/conftest.py` to avoid KeyError during app creation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install -r requirements.txt` *(fails: could not fetch packages due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684c8666a5e08320a46a1d20cd79c8ff