### PR TITLE
Add missing frontend dependencies

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,14 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.23.0"
+    "react-router-dom": "^6.23.0",
+    "axios": "^1.6.7",
+    "chart.js": "^4.4.1",
+    "file-saver": "^2.0.5",
+    "jspdf": "^2.5.1",
+    "jspdf-autotable": "^3.5.28",
+    "react-chartjs-2": "^5.2.0",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.0",


### PR DESCRIPTION
## Summary
- add axios, chart.js, file-saver, jspdf, jspdf-autotable, react-chartjs-2 and xlsx dependencies for the React app

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68507067d03483208ea22053b5b63710