### PR TITLE
Add psycopg2 dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ requests
 pytest
 python-dotenv
 gunicorn==20.1.0
+psycopg2-binary==2.9.6


### PR DESCRIPTION
## Summary
- add `psycopg2-binary==2.9.6` to `requirements.txt`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6850d426f8a48320b825196c24b08268