### PR TITLE
Update requirements and env sample

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,8 +1,5 @@
-DATABASE_URL=postgresql+pg8000://kiba_user:<TU_PASS>@<HOST>:5432/kiba_db
-JWT_SECRET=<TU_JWT_SECRET>
-HABLAME_ACCOUNT=<TU_ACCOUNT>
-HABLAME_APIKEY=<TU_APIKEY>
-HABLAME_TOKEN=<TU_TOKEN>
-FRONTEND_URL=https://kiba-frontend.onrender.com
-LOG_LEVEL=INFO
-FLASK_ENV=production
+DATABASE_URL=postgresql+pg8000://<USER>:<PASSWORD>@<HOST>:<PORT>/<DB_NAME>
+JWT_SECRET=<tu_clave_secreta>
+HABLAME_ACCOUNT=<tu_cuenta>
+HABLAME_APIKEY=<tu_apikey>
+HABLAME_TOKEN=<tu_token>

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,7 @@ bcrypt>=4.3.0
 requests>=2.32.4
 python-dotenv>=1.1.0
 gunicorn==20.1.0
-psycopg2-binary==2.9.6
-mypy>=1.5.1
-bandit>=1.7.2
+mypy>=1.16.1
+bandit>=1.8.5
 pytest
 pg8000==1.31.2


### PR DESCRIPTION
## Summary
- remove deprecated `psycopg2-binary`
- bump lint tools versions
- add Render-compatible `.env.sample`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6850e27c31c88320a8a2fff08ca630af