### PR TITLE
Ensure SQLAlchemy uses pg8000 driver

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -9,7 +9,10 @@ db = SQLAlchemy()
 def create_app():
     app = Flask(__name__)
     # Database connection string
-    app.config['SQLALCHEMY_DATABASE_URI'] = os.environ['DATABASE_URL']
+    db_uri = os.environ["DATABASE_URL"]
+    if db_uri.startswith("postgresql://"):
+        db_uri = db_uri.replace("postgresql://", "postgresql+pg8000://", 1)
+    app.config["SQLALCHEMY_DATABASE_URI"] = db_uri
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
     # Secret used to sign JWTs and sessions
     app.config['SECRET_KEY'] = os.environ['JWT_SECRET']


### PR DESCRIPTION
## Summary
- update DB URI configuration to prefer the `postgresql+pg8000` driver when the env variable still uses `postgresql://`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6850e27f253083209d58bf03726bee26