### PR TITLE
Render deployment updates

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,5 @@
 DATABASE_URL=postgresql+pg8000://<USER>:<PASSWORD>@<HOST>:<PORT>/<DB_NAME>
-JWT_SECRET=<tu_clave_secreta>
-HABLAME_ACCOUNT=<tu_cuenta>
-HABLAME_APIKEY=<tu_apikey>
-HABLAME_TOKEN=<tu_token>
+JWT_SECRET=change_me
+HABLAME_ACCOUNT=your_account
+HABLAME_APIKEY=your_apikey
+HABLAME_TOKEN=your_token

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - run: cd frontend && npm install
+      - run: cd frontend && npm run build

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build --outDir frontend/dist",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -13,6 +13,17 @@ export default defineConfig(({ mode }) => {
           changeOrigin: true
         }
       }
+    },
+    build: {
+      outDir: 'frontend/dist',
+      chunkSizeWarningLimit: 500,
+      rollupOptions: {
+        output: {
+          manualChunks(id) {
+            if (id.includes('node_modules')) return 'vendor'
+          }
+        }
+      }
     }
   }
 })

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,9 @@
+services:
+  - name: kiba-backend
+    env: python
+    buildCommand: pip install -r requirements.txt
+    startCommand: gunicorn backend.app.main:app
+  - name: kiba-frontend
+    env: node
+    buildCommand: npm install && npm audit fix --force && npm run build
+    publish: frontend/dist


### PR DESCRIPTION
## Summary
- update `.env.sample` for easier Render deployment
- configure Vite output location and bundling
- add Render services description
- add basic GitHub workflow for installing and building backend and frontend

## Testing
- `npm audit fix --force` *(fails: ENOLOCK)*
- `npm i --package-lock-only` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6850ef32f0748320b291389a6fe723a7