### PR TITLE
Add admin seeding and new login flow

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,7 @@ from dotenv import load_dotenv
 from flask_cors import CORS
 from backend.app.config import create_app, db
 from backend.app.models.user import Usuario, Rol
+from backend.app.utils.default_user import seed_default_admin
 from backend.app.models.sms import Especialidad, SMS
 from backend.app.models.confirmacion import Confirmacion
 from backend.app.routes.auth import auth_bp
@@ -27,6 +28,9 @@ app.register_blueprint(cita_bp, url_prefix='/api')
 app.register_blueprint(sms_bp, url_prefix='/api')
 migrate = Migrate(app, db)
 app.register_blueprint(confirmacion_bp, url_prefix='/api')
+
+with app.app_context():
+    seed_default_admin()
 
 
 @app.route('/')

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -6,6 +6,27 @@ from backend.app.utils.token_manager import generar_token, token_requerido
 
 auth_bp = Blueprint('auth', __name__)
 
+
+@auth_bp.route('/auth/login', methods=['POST'])
+def login_v2():
+    """Login endpoint using email and password with detailed errors."""
+    datos = request.get_json() or {}
+    email = datos.get('email')
+    password = datos.get('password')
+
+    if not email or not password:
+        return jsonify({'success': False, 'error': 'Faltan credenciales'}), 400
+
+    usuario = Usuario.query.filter_by(correo=email).first()
+    if not usuario:
+        return jsonify({'success': False, 'error': 'Email no registrado'}), 404
+
+    if not usuario.verificar_contrasena(password):
+        return jsonify({'success': False, 'error': 'Contraseña incorrecta'}), 401
+
+    token = generar_token(usuario)
+    return jsonify({'success': True, 'token': token})
+
 @auth_bp.route('/login', methods=['POST'])
 def login():
     datos = request.get_json()

--- a/backend/app/utils/default_user.py
+++ b/backend/app/utils/default_user.py
@@ -1,0 +1,20 @@
+from backend.app.config import db
+from backend.app.models.user import Usuario, Rol
+
+
+def seed_default_admin():
+    """Create default admin user if it doesn't exist."""
+    admin_email = "admin@example.com"
+    if Usuario.query.filter_by(correo=admin_email).first():
+        return
+
+    admin_role = Rol.query.filter_by(nombre="Administrador").first()
+    if not admin_role:
+        admin_role = Rol(nombre="Administrador")
+        db.session.add(admin_role)
+        db.session.commit()
+
+    user = Usuario(correo=admin_email, rol=admin_role)
+    user.set_contrasena("Admin123!")
+    db.session.add(user)
+    db.session.commit()

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -5,26 +5,33 @@ import api from '../api';
 import { useAuth } from '../AuthContext';
 
 export default function Login() {
-  const [correo, setCorreo] = useState('');
-  const [contrasena, setContrasena] = useState('');
-  const [error, setError] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [emailError, setEmailError] = useState('');
+  const [passwordError, setPasswordError] = useState('');
+  const [genericError, setGenericError] = useState('');
   const navigate = useNavigate();
   const { login } = useAuth();
 
   const handleLogin = async (e) => {
     e.preventDefault();
+    setEmailError('');
+    setPasswordError('');
+    setGenericError('');
     try {
-      const response = await api.post('/login', {
-        correo,
-        contrasena
-      });
-
-      if (response.data.token) {
-        login(response.data.token, { correo, rol: response.data.rol });
+      const { data } = await api.post('/auth/login', { email, password });
+      if (data.success) {
+        login(data.token, { email });
         navigate('/dashboard');
+      } else if (data.error === 'Email no registrado') {
+        setEmailError(data.error);
+      } else if (data.error === 'Contraseña incorrecta') {
+        setPasswordError(data.error);
+      } else {
+        setGenericError(data.error || 'Error al iniciar sesión');
       }
     } catch (err) {
-      setError('Credenciales incorrectas');
+      setGenericError('Error al iniciar sesión');
     }
   };
 
@@ -33,26 +40,32 @@ export default function Login() {
       <form onSubmit={handleLogin} className="bg-white shadow-xl rounded-lg p-8 w-full max-w-md">
         <h2 className="text-2xl font-bold text-blue-600 mb-6 text-center">Iniciar Sesión - Kiba</h2>
 
-        {error && <p className="text-red-600 text-sm mb-4">{error}</p>}
+        {genericError && (
+          <div className="alert alert-danger mb-4">{genericError}</div>
+        )}
 
         <div className="mb-4">
-          <label className="block mb-1 font-semibold">Correo</label>
+          {emailError && <div className="alert alert-danger mb-2">{emailError}</div>}
+          <label className="block mb-1 font-semibold">Email</label>
           <input
             type="email"
             className="w-full border px-4 py-2 rounded-lg"
-            value={correo}
-            onChange={(e) => setCorreo(e.target.value)}
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
             required
           />
         </div>
 
         <div className="mb-6">
+          {passwordError && (
+            <div className="alert alert-danger mb-2">{passwordError}</div>
+          )}
           <label className="block mb-1 font-semibold">Contraseña</label>
           <input
             type="password"
             className="w-full border px-4 py-2 rounded-lg"
-            value={contrasena}
-            onChange={(e) => setContrasena(e.target.value)}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
             required
           />
         </div>


### PR DESCRIPTION
## Summary
- seed a default admin user on app startup
- implement `/auth/login` route with clear error responses
- adjust backend app to call seeding logic
- update React login page to consume new endpoint and show alerts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6850f28d41e88320b6171ba242ea6259