### PR TITLE
Handle multiple postgres prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 The backend relies on several environment variables:
 
-- `DATABASE_URL` &ndash; SQLAlchemy connection string for the application's database.
+- `DATABASE_URL` &ndash; SQLAlchemy connection string for the application's database. Use a
+  `postgres://` or `postgresql://` URL. Either style will be converted internally to
+  `postgresql+pg8000://` for SQLAlchemy.
 - `JWT_SECRET` &ndash; secret used to sign JWTs and Flask sessions.
 - `HABLAME_ACCOUNT` &ndash; account identifier for the Hablame SMS API.
 - `HABLAME_APIKEY` &ndash; API key for the Hablame SMS API.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -10,7 +10,9 @@ def create_app():
     app = Flask(__name__)
     # Database connection string
     db_uri = os.environ["DATABASE_URL"]
-    if db_uri.startswith("postgresql://"):
+    if db_uri.startswith("postgres://"):
+        db_uri = db_uri.replace("postgres://", "postgresql+pg8000://", 1)
+    elif db_uri.startswith("postgresql://"):
         db_uri = db_uri.replace("postgresql://", "postgresql+pg8000://", 1)
     app.config["SQLALCHEMY_DATABASE_URI"] = db_uri
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,18 @@
+import os
+from backend.app.config import create_app
+
+def setup_env(url):
+    os.environ["DATABASE_URL"] = url
+    os.environ["JWT_SECRET"] = "testsecret"
+
+
+def test_postgres_url_converted(monkeypatch):
+    setup_env("postgres://user:pass@localhost/db")
+    app = create_app()
+    assert app.config["SQLALCHEMY_DATABASE_URI"] == "postgresql+pg8000://user:pass@localhost/db"
+
+
+def test_postgresql_url_converted(monkeypatch):
+    setup_env("postgresql://user:pass@localhost/db")
+    app = create_app()
+    assert app.config["SQLALCHEMY_DATABASE_URI"] == "postgresql+pg8000://user:pass@localhost/db"


### PR DESCRIPTION
## Summary
- support `postgres://` and `postgresql://` URLs in the backend config
- document accepted DB URL prefixes
- test that both forms are converted to `postgresql+pg8000://`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6850facc81bc83209638ff170c4d50d9