### PR TITLE
Update env var docs and cleanup samples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-DATABASE_URL=postgresql://user:password@db:5432/kiba
+DATABASE_URL=postgresql+pg8000://user:password@db:5432/kiba
 JWT_SECRET=una_clave_secreta_segura
 HABLAME_ACCOUNT=cuenta_hablame
 HABLAME_APIKEY=apikey_hablame

--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,0 @@
-DATABASE_URL=postgresql+pg8000://<USER>:<PASSWORD>@<HOST>:<PORT>/<DB_NAME>
-JWT_SECRET=change_me
-HABLAME_ACCOUNT=your_account
-HABLAME_APIKEY=your_apikey
-HABLAME_TOKEN=your_token

--- a/README.md
+++ b/README.md
@@ -4,7 +4,12 @@
 
 The backend relies on several environment variables:
 
-- `DATABASE_URL` &ndash; SQLAlchemy connection string for the application's database.
+- `DATABASE_URL` &ndash; SQLAlchemy connection string for the application's
+  database. Use the standard PostgreSQL format:
+  `postgresql://<USER>:<PASSWORD>@<HOST>:<PORT>/<DB_NAME>`. If you rely on the
+  `pg8000` driver the string must instead start with the
+  `postgresql+pg8000://` prefix. The credentials included here must match the
+  actual database you want the application to connect to.
 - `JWT_SECRET` &ndash; secret used to sign JWTs and Flask sessions.
 - `HABLAME_ACCOUNT` &ndash; account identifier for the Hablame SMS API.
 - `HABLAME_APIKEY` &ndash; API key for the Hablame SMS API.
@@ -93,4 +98,4 @@ Configure the service on [Render](https://render.com) with the following setting
 }
 ```
 
-Add the environment variables from `.env.sample` in the Render dashboard so that the container boots correctly.
+Add the environment variables from `.env.example` in the Render dashboard so that the container boots correctly.


### PR DESCRIPTION
## Summary
- document full DATABASE_URL format and pg8000 prefix
- reference .env.example in Render docs
- remove duplicate .env.sample

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6850facf05188320b48526e6340e5dbd