### PR TITLE
Link confirmations with SMS

### DIFF
--- a/backend/app/routes/cita.py
+++ b/backend/app/routes/cita.py
@@ -4,7 +4,7 @@ from flask import Blueprint, request, jsonify
 from backend.app.config import db
 from backend.app.models.cita import Cita
 from backend.app.models.paciente import Paciente
-from backend.app.models.sms import Especialidad
+from backend.app.models.sms import Especialidad, SMS
 from backend.app.utils.token_manager import token_requerido
 from datetime import datetime
 from backend.app.models.confirmacion import Confirmacion
@@ -69,7 +69,11 @@ def confirmar_cita():
     if not cita:
         return jsonify({'error': 'Cita no encontrada'}), 404
 
-    confirmacion = Confirmacion(cita_id=cita.id)
+    sms = SMS.query.filter_by(celular=celular).order_by(SMS.fecha_envio.desc()).first()
+    if not sms:
+        return jsonify({'error': 'SMS relacionado no encontrado'}), 404
+
+    confirmacion = Confirmacion(cita_id=cita.id, sms_id=sms.id)
     db.session.add(confirmacion)
     db.session.commit()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ from backend.app.config import create_app, db
 from backend.app.routes.sms import sms_bp
 from backend.app.routes.auth import auth_bp
 from backend.app.routes.confirmacion import confirmacion_bp
+from backend.app.routes.cita import cita_bp
 
 
 @pytest.fixture
@@ -18,6 +19,7 @@ def app():
     app.register_blueprint(sms_bp, url_prefix="/api")
     app.register_blueprint(auth_bp, url_prefix="/api")
     app.register_blueprint(confirmacion_bp, url_prefix="/api")
+    app.register_blueprint(cita_bp, url_prefix="/api")
     app.config["TESTING"] = True
     with app.app_context():
         db.create_all()

--- a/tests/test_cita_confirmar.py
+++ b/tests/test_cita_confirmar.py
@@ -1,0 +1,54 @@
+from datetime import datetime
+from backend.app.config import db
+from backend.app.models.sms import SMS, Especialidad
+from backend.app.models.paciente import Paciente
+from backend.app.models.cita import Cita
+from backend.app.models.user import Rol, Usuario
+
+
+def seed_user():
+    admin_role = Rol(nombre="Administrador")
+    operator_role = Rol(nombre="Operador")
+    db.session.add_all([admin_role, operator_role])
+    user = Usuario(correo="user@example.com", rol=admin_role)
+    user.set_contrasena("secret123")
+    db.session.add(user)
+    db.session.commit()
+
+
+def get_token(client, app):
+    with app.app_context():
+        seed_user()
+    resp = client.post(
+        "/api/login",
+        json={"correo": "user@example.com", "contrasena": "secret123"},
+    )
+    return resp.get_json()["token"]
+
+
+def seed_data():
+    esp = Especialidad(nombre="General")
+    db.session.add(esp)
+    paciente = Paciente(nombre="Ana", celular="123", especialidad=esp)
+    db.session.add(paciente)
+    fecha = datetime.now().replace(microsecond=0)
+    cita = Cita(paciente=paciente, especialidad=esp, fecha_hora=fecha)
+    sms = SMS(celular="123", mensaje="hola", especialidad=esp, fecha_envio=fecha)
+    db.session.add_all([cita, sms])
+    db.session.commit()
+    return paciente, cita, sms
+
+
+def test_confirmar_cita_creates_confirmation(client, app):
+    token = get_token(client, app)
+    with app.app_context():
+        paciente, cita, sms = seed_data()
+    resp = client.post(
+        "/api/confirmar-cita",
+        headers={"Authorization": token},
+        json={"celular": "123", "fecha_hora": cita.fecha_hora.strftime("%Y-%m-%d %H:%M:%S")},
+    )
+    assert resp.status_code == 200
+    with app.app_context():
+        conf = cita.confirmaciones[0]
+        assert conf.sms_id == sms.id


### PR DESCRIPTION
## Summary
- ensure `confirmar_cita` associates a confirmation with the most recent SMS for the patient
- expose cita routes for tests
- test confirmation creation against SMS record

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask>=3.1.0)*

------
https://chatgpt.com/codex/tasks/task_e_6850fac770488320a9966e4d51c5fdad