### PR TITLE
Add default admin credentials configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,5 @@ HABLAME_TOKEN=token_hablame
 # API_HABLAME_KEY=clave_real_o_ficticia  # unused
 FRONTEND_URL=http://localhost:3000
 # BACKEND_URL=http://localhost:5000  # unused
+DEFAULT_ADMIN_EMAIL=admin@example.com
+DEFAULT_ADMIN_PASSWORD=Admin123!

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ The backend relies on several environment variables:
 - `FRONTEND_URL` &ndash; URL where the React frontend is served.
 - `API_HABLAME_KEY` &ndash; legacy key, currently unused.
 - `BACKEND_URL` &ndash; unused base URL variable.
+- `DEFAULT_ADMIN_EMAIL` &ndash; email for the initial admin user created on startup.
+- `DEFAULT_ADMIN_PASSWORD` &ndash; password for that user.
+
+If these credentials are not provided, no admin account will be seeded automatically.
 
 A `.env.example` file contains these variables with placeholder values. Copy it to
 `.env` and edit it with your credentials. Ensure the variables are loaded

--- a/backend/app/utils/default_user.py
+++ b/backend/app/utils/default_user.py
@@ -1,10 +1,16 @@
+import os
 from backend.app.config import db
 from backend.app.models.user import Usuario, Rol
 
 
 def seed_default_admin():
-    """Create default admin user if it doesn't exist."""
-    admin_email = "admin@example.com"
+    """Create default admin user if credentials are provided."""
+    admin_email = os.getenv("DEFAULT_ADMIN_EMAIL")
+    admin_password = os.getenv("DEFAULT_ADMIN_PASSWORD")
+
+    if not admin_email or not admin_password:
+        return
+
     if Usuario.query.filter_by(correo=admin_email).first():
         return
 
@@ -15,6 +21,6 @@ def seed_default_admin():
         db.session.commit()
 
     user = Usuario(correo=admin_email, rol=admin_role)
-    user.set_contrasena("Admin123!")
+    user.set_contrasena(admin_password)
     db.session.add(user)
     db.session.commit()


### PR DESCRIPTION
## Summary
- include `DEFAULT_ADMIN_EMAIL` and `DEFAULT_ADMIN_PASSWORD` examples in `.env.example`
- let `seed_default_admin` read credentials from the environment and skip creation if unset
- document new variables in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6850fac9fe04832099cec23caef4f0a6