### PR TITLE
Enhance backend startup with Sentry, metrics and admin seeding

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -6,23 +6,35 @@ from flask import Flask, jsonify
 from flask_sqlalchemy import SQLAlchemy
 from werkzeug.exceptions import HTTPException
 
+# Ajuste automático de esquema para pg8000 o psycopg2
+url = os.getenv("DATABASE_URL", "")
+if url.startswith("postgres://"):
+    # si usas pg8000:
+    url = url.replace("postgres://", "postgresql+pg8000://", 1)
+    # o si prefieres psycopg2, comenta la línea anterior y descomenta:
+    # url = url.replace("postgres://", "postgresql+psycopg2://", 1)
+
+SQLALCHEMY_DATABASE_URI = url
+SQLALCHEMY_TRACK_MODIFICATIONS = False
+
+# Configuración de Sentry
+SENTRY_DSN = os.getenv("SENTRY_DSN", None)
+
 logging.basicConfig(
     level=os.getenv("LOG_LEVEL", "INFO"),
     format="%(asctime)s %(levelname)s %(name)s %(message)s",
 )
 logger = logging.getLogger(__name__)
-logger.info("Usando DATABASE_URL: %s", os.getenv("DATABASE_URL"))
+logger.info("Usando DATABASE_URL: %s", SQLALCHEMY_DATABASE_URI)
 
 db = SQLAlchemy()
 
 def create_app():
     app = Flask(__name__)
-    # Database connection string
-    db_uri = os.getenv("DATABASE_URL")
-    app.config["SQLALCHEMY_DATABASE_URI"] = db_uri
-    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-    # Secret used to sign JWTs and sessions
-    app.config['SECRET_KEY'] = os.environ['JWT_SECRET']
+    app.config["SQLALCHEMY_DATABASE_URI"] = SQLALCHEMY_DATABASE_URI
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = SQLALCHEMY_TRACK_MODIFICATIONS
+    app.config["SECRET_KEY"] = os.environ["JWT_SECRET"]
+    app.config["SENTRY_DSN"] = SENTRY_DSN
 
     register_error_handlers(app)
 

--- a/backend/app/utils/default_user.py
+++ b/backend/app/utils/default_user.py
@@ -3,25 +3,27 @@ import os
 from backend.app.config import db
 from backend.app.models.user import Usuario, Rol
 
-logger = logging.getLogger(__name__)
+log = logging.getLogger("backend.seed")
 
 
 def seed_default_admin():
-    """Create default admin user if credentials are provided."""
-    admin_email = os.getenv("ADMIN_EMAIL", "admin@example.com")
-    admin_password = os.getenv("ADMIN_PASS", "Admin123!")
     try:
-        if not Usuario.query.filter_by(correo=admin_email).first():
+        admin_email = os.getenv("ADMIN_EMAIL", "admin@example.com")
+        admin_password = os.getenv("ADMIN_PASS", "Admin123!")
+        log.info("Comprobando existencia de admin %s", admin_email)
+        usuario = Usuario.query.filter_by(correo=admin_email).first()
+        if not usuario:
+            log.info("Creando usuario admin por defecto")
             admin_role = Rol.query.filter_by(nombre="Administrador").first()
             if not admin_role:
                 admin_role = Rol(nombre="Administrador")
                 db.session.add(admin_role)
                 db.session.commit()
-
             user = Usuario(correo=admin_email, rol=admin_role)
             user.set_contrasena(admin_password)
             db.session.add(user)
             db.session.commit()
-            logger.info("Usuario admin por defecto sembrado: %s", admin_email)
+        else:
+            log.info("Usuario admin ya existe")
     except Exception:
-        logger.exception("Fallo al sembrar el usuario admin por defecto")
+        log.exception("Error al sembrar admin por defecto")

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ pytest
 pg8000==1.31.2
 sentry-sdk>=1.39.1
 prometheus-client>=0.20.0
+psycopg2-binary>=2.9.6


### PR DESCRIPTION
## Summary
- add `psycopg2-binary` to requirements
- auto adjust postgres connection URL
- initialize CORS, Sentry, Prometheus metrics and logging in `main.py`
- improve admin seeding logging
- expose `/health` endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6852191eb50c83208e3553e1f9e97666