### PR TITLE
Fix admin password creation method

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -48,9 +48,9 @@ def cargar_datos():
         if not Usuario.query.filter_by(correo='admin@kiba.com').first():
             admin = Usuario(
                 correo='admin@kiba.com',
-                contrasena='admin123',
                 rol_id=1
             )
+            admin.set_contrasena('admin123')
             db.session.add(admin)
 
         db.session.commit()


### PR DESCRIPTION
## Summary
- use `set_contrasena` when creating the admin account in `cargar_datos`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68537a3d1e588320945deced9fd75302