### PR TITLE
Update login request keys

### DIFF
--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -19,7 +19,10 @@ export default function Login() {
     setPasswordError('');
     setGenericError('');
     try {
-      const { data } = await api.post('/login', { email, password });
+      const { data } = await api.post('/login', {
+        correo: email,
+        contrasena: password,
+      });
       if (data.success) {
         login(data.token, { email });
         navigate('/dashboard');


### PR DESCRIPTION
## Summary
- send `correo` and `contrasena` when logging in

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm run build --prefix frontend` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68537a402cec8320a53e6b28536e7d87