### PR TITLE
Add seed_user fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ from backend.app.routes.sms import sms_bp
 from backend.app.routes.auth import auth
 from backend.app.routes.confirmacion import confirmacion_bp
 from backend.app.routes.cita import cita_bp
+from backend.app.models.user import Rol, Usuario
 
 
 @pytest.fixture
@@ -31,3 +32,17 @@ def app():
 @pytest.fixture
 def client(app):
     return app.test_client()
+
+
+@pytest.fixture
+def seed_user(app):
+    """Seed default roles and a test user."""
+    with app.app_context():
+        admin_role = Rol(nombre="Administrador")
+        operator_role = Rol(nombre="Operador")
+        db.session.add_all([admin_role, operator_role])
+        user = Usuario(correo="user@example.com", rol=admin_role)
+        user.set_contrasena("secret123")
+        db.session.add(user)
+        db.session.commit()
+        return user

--- a/tests/test_auth_endpoints.py
+++ b/tests/test_auth_endpoints.py
@@ -1,20 +1,4 @@
-from backend.app.config import db
-from backend.app.models.user import Rol, Usuario
-
-
-def seed_user():
-    admin_role = Rol(nombre="Administrador")
-    operator_role = Rol(nombre="Operador")
-    db.session.add_all([admin_role, operator_role])
-    user = Usuario(correo="user@example.com", rol=admin_role)
-    user.set_contrasena("secret123")
-    db.session.add(user)
-    db.session.commit()
-
-
-def test_login_success(client, app):
-    with app.app_context():
-        seed_user()
+def test_login_success(client, seed_user):
     resp = client.post(
         "/api/login",
         json={"correo": "user@example.com", "contrasena": "secret123"},
@@ -25,9 +9,7 @@ def test_login_success(client, app):
     assert data["rol"] == "Administrador"
 
 
-def test_login_invalid_password(client, app):
-    with app.app_context():
-        seed_user()
+def test_login_invalid_password(client, seed_user):
     resp = client.post(
         "/api/login",
         json={"correo": "user@example.com", "contrasena": "wrong"},
@@ -43,9 +25,7 @@ def test_login_unknown_user(client):
     assert resp.status_code == 404
 
 
-def test_authenticated_profile(client, app):
-    with app.app_context():
-        seed_user()
+def test_authenticated_profile(client, seed_user):
     login_resp = client.post(
         "/api/login",
         json={"correo": "user@example.com", "contrasena": "secret123"},

--- a/tests/test_cita_confirmar.py
+++ b/tests/test_cita_confirmar.py
@@ -3,22 +3,9 @@ from backend.app.config import db
 from backend.app.models.sms import SMS, Especialidad
 from backend.app.models.paciente import Paciente
 from backend.app.models.cita import Cita
-from backend.app.models.user import Rol, Usuario
 
 
-def seed_user():
-    admin_role = Rol(nombre="Administrador")
-    operator_role = Rol(nombre="Operador")
-    db.session.add_all([admin_role, operator_role])
-    user = Usuario(correo="user@example.com", rol=admin_role)
-    user.set_contrasena("secret123")
-    db.session.add(user)
-    db.session.commit()
-
-
-def get_token(client, app):
-    with app.app_context():
-        seed_user()
+def get_token(client, seed_user):
     resp = client.post(
         "/api/login",
         json={"correo": "user@example.com", "contrasena": "secret123"},
@@ -39,8 +26,8 @@ def seed_data():
     return paciente, cita, sms
 
 
-def test_confirmar_cita_creates_confirmation(client, app):
-    token = get_token(client, app)
+def test_confirmar_cita_creates_confirmation(client, app, seed_user):
+    token = get_token(client, seed_user)
     with app.app_context():
         paciente, cita, sms = seed_data()
     resp = client.post(

--- a/tests/test_confirmacion_endpoints.py
+++ b/tests/test_confirmacion_endpoints.py
@@ -1,20 +1,4 @@
-from backend.app.config import db
-from backend.app.models.user import Rol, Usuario
-
-
-def seed_user():
-    admin_role = Rol(nombre="Administrador")
-    operator_role = Rol(nombre="Operador")
-    db.session.add_all([admin_role, operator_role])
-    user = Usuario(correo="user@example.com", rol=admin_role)
-    user.set_contrasena("secret123")
-    db.session.add(user)
-    db.session.commit()
-
-
-def get_token(client, app):
-    with app.app_context():
-        seed_user()
+def get_token(client, seed_user):
     resp = client.post(
         "/api/login",
         json={"correo": "user@example.com", "contrasena": "secret123"},
@@ -27,7 +11,7 @@ def test_confirmaciones_requires_token(client):
     assert resp.status_code == 401
 
 
-def test_confirmaciones_with_token(client, app):
-    token = get_token(client, app)
+def test_confirmaciones_with_token(client, seed_user):
+    token = get_token(client, seed_user)
     resp = client.get("/api/confirmaciones", headers={"Authorization": token})
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- provide a fixture to seed default roles and a sample user
- use the fixture across tests instead of duplicating logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68537a480d488320b589c1308099ac25