### PR TITLE
Mask database URL in logs

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -5,6 +5,7 @@ import os
 from flask import Flask, jsonify
 from flask_sqlalchemy import SQLAlchemy
 from werkzeug.exceptions import HTTPException
+from urllib.parse import urlparse
 
 # Ajuste automático de esquema para pg8000 o psycopg2
 url = os.getenv("DATABASE_URL", "")
@@ -25,7 +26,13 @@ logging.basicConfig(
     format="%(asctime)s %(levelname)s %(name)s %(message)s",
 )
 logger = logging.getLogger(__name__)
-logger.info("Usando DATABASE_URL: %s", SQLALCHEMY_DATABASE_URI)
+_parsed = urlparse(SQLALCHEMY_DATABASE_URI)
+_masked = f"{_parsed.scheme}://{_parsed.hostname or ''}"
+if _parsed.port:
+    _masked += f":{_parsed.port}"
+if _parsed.path:
+    _masked += _parsed.path
+logger.info("Usando DATABASE_URL: %s", _masked)
 
 db = SQLAlchemy()
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,7 @@
 import os
 from backend.app.config import create_app
+import importlib
+import logging
 
 def setup_env(url):
     os.environ["DATABASE_URL"] = url
@@ -18,3 +20,12 @@ def test_postgresql_url_usado(monkeypatch):
     setup_env(url)
     app = create_app()
     assert app.config["SQLALCHEMY_DATABASE_URI"] == url
+
+
+def test_log_message_masked(monkeypatch, caplog):
+    url = "postgresql://user:pass@localhost/db"
+    setup_env(url)
+    with caplog.at_level(logging.INFO):
+        importlib.reload(importlib.import_module("backend.app.config"))
+    messages = "".join(record.getMessage() for record in caplog.records)
+    assert "pass" not in messages


### PR DESCRIPTION
## Summary
- mask connection info in log output
- ensure password not logged in tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6853831eb534832099ef52ad23cb1229