### PR TITLE
Handle invalid dates

### DIFF
--- a/backend/app/routes/cita.py
+++ b/backend/app/routes/cita.py
@@ -31,7 +31,10 @@ def crear_cita():
         return jsonify({'error': 'Paciente no encontrado'}), 404
 
     # Verificar si el paciente ya tiene una cita a esa misma hora
-    fecha_obj = datetime.strptime(fecha_hora, '%Y-%m-%d %H:%M:%S')
+    try:
+        fecha_obj = datetime.strptime(fecha_hora, '%Y-%m-%d %H:%M:%S')
+    except ValueError:
+        return jsonify({'error': 'Formato de fecha inválido. Usa YYYY-MM-DD HH:MM:SS'}), 400
     conflicto = Cita.query.filter_by(paciente_id=paciente.id, fecha_hora=fecha_obj).first()
     if conflicto:
         return jsonify({'error': 'El paciente ya tiene una cita programada en esa hora'}), 409

--- a/backend/app/routes/paciente.py
+++ b/backend/app/routes/paciente.py
@@ -28,11 +28,18 @@ def crear_paciente():
     if Paciente.query.filter_by(celular=celular).first():
         return jsonify({'error': 'Ya existe un paciente con este celular.'}), 400
 
+    programada_dt = None
+    if programada:
+        try:
+            programada_dt = datetime.strptime(programada, '%Y-%m-%d %H:%M:%S')
+        except ValueError:
+            return jsonify({'error': 'Formato de fecha inválido. Usa YYYY-MM-DD HH:MM:SS'}), 400
+
     nuevo_paciente = Paciente(
         nombre=nombre,
         celular=celular,
         especialidad_id=especialidad_id,
-        programada=datetime.strptime(programada, '%Y-%m-%d %H:%M:%S') if programada else None
+        programada=programada_dt
     )
 
     db.session.add(nuevo_paciente)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ from backend.app.routes.sms import sms_bp
 from backend.app.routes.auth import auth
 from backend.app.routes.confirmacion import confirmacion_bp
 from backend.app.routes.cita import cita_bp
+from backend.app.routes.paciente import paciente_bp
 from backend.app.models.user import Rol, Usuario
 
 
@@ -21,6 +22,7 @@ def app():
     app.register_blueprint(auth, url_prefix="/api")
     app.register_blueprint(confirmacion_bp, url_prefix="/api")
     app.register_blueprint(cita_bp, url_prefix="/api")
+    app.register_blueprint(paciente_bp, url_prefix="/api")
     app.config["TESTING"] = True
     with app.app_context():
         db.create_all()

--- a/tests/test_cita_confirmar.py
+++ b/tests/test_cita_confirmar.py
@@ -39,3 +39,42 @@ def test_confirmar_cita_creates_confirmation(client, app, seed_user):
     with app.app_context():
         conf = cita.confirmaciones[0]
         assert conf.sms_id == sms.id
+
+
+def test_crear_cita_fecha_invalida(client, app, seed_user):
+    token = get_token(client, seed_user)
+    with app.app_context():
+        esp = Especialidad(nombre="General")
+        db.session.add(esp)
+        paciente = Paciente(nombre="Ana", celular="555", especialidad=esp)
+        db.session.add(paciente)
+        db.session.commit()
+        esp_id = esp.id
+
+    resp = client.post(
+        "/api/citas",
+        headers={"Authorization": token},
+        json={"celular": "555", "especialidad_id": esp_id, "fecha_hora": "bad"},
+    )
+    assert resp.status_code == 400
+
+
+def test_crear_paciente_programada_invalida(client, app, seed_user):
+    token = get_token(client, seed_user)
+    with app.app_context():
+        esp = Especialidad(nombre="General")
+        db.session.add(esp)
+        db.session.commit()
+        esp_id = esp.id
+
+    resp = client.post(
+        "/api/pacientes",
+        headers={"Authorization": token},
+        json={
+            "nombre": "Ana",
+            "celular": "777",
+            "especialidad_id": esp_id,
+            "programada": "not-a-date",
+        },
+    )
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- validate date parsing for new appointment route
- validate date parsing for new patient route
- register patient blueprint in tests
- test invalid date cases

## Testing
- `pytest -q tests/test_cita_confirmar.py::test_crear_paciente_programada_invalida` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685383258b1483209b974928f5123ac8