### PR TITLE
Remove mypy and bandit from install requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ python manage.py runserver
 
 La API estará disponible en `http://localhost:5000/`.
 
+### Herramientas de desarrollo opcionales
+
+Para análisis estático puedes instalar manualmente `mypy` y `bandit`. Estas
+dependencias no forman parte de `requirements.txt` para mantener liviano el
+entorno de producción.
+
 ## Desarrollo del frontend
 
 Dentro de `frontend/` se encuentra el proyecto Vite + React:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,6 @@ bcrypt>=4.3.0
 requests>=2.32.4
 python-dotenv>=1.1.0
 gunicorn==20.1.0
-mypy>=1.16.1
-bandit>=1.8.5
 pytest
 pg8000==1.31.2
 sentry-sdk>=1.39.1


### PR DESCRIPTION
## Summary
- remove mypy and bandit from requirements
- document optional static analysis tools in README

## Testing
- `pytest -q` *(fails: pyenv: version `3.11.9` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68538328819883209325e95d58c05705