### PR TITLE
Clarify PostgreSQL default and optional MySQL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
 DATABASE_URL=postgresql://user:password@db:5432/kiba
+# Para usar MySQL instala PyMySQL y ajusta la siguiente cadena
+# DATABASE_URL=mysql+pymysql://user:password@localhost:3306/kiba
 JWT_SECRET=change_me
 HABLAME_ACCOUNT=your_account
 HABLAME_APIKEY=your_apikey

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # KIBA
 
 Aplicación de gestión de citas y envío de SMS basada en **Flask** y **React**.
-Incluye autenticación por JWT y base de datos PostgreSQL.
+PostgreSQL es la base de datos principal del proyecto e incluye autenticación por JWT.
 
 ## Variables de entorno
 
@@ -14,7 +14,7 @@ Copie el archivo `.env.example` a `.env` y complete con al menos:
 - `ADMIN_EMAIL` y `ADMIN_PASS` – datos del administrador inicial.
 - `SENTRY_DSN` – opcional, para reportar errores.
 
-## Base de datos
+## Base de datos (PostgreSQL por defecto)
 
 Para desarrollo local utilizamos **PostgreSQL**. Cree la base de datos y ejecute
 el esquema inicial con:
@@ -60,10 +60,10 @@ Puede construir la imagen y levantar todo el entorno con:
 docker-compose up --build
 ```
 
-## Uso de MySQL de XAMPP en Windows 10
+## Uso opcional con MySQL
 
-Si trabajas en Windows 10 con XAMPP puedes utilizar el servicio de MySQL que
-viene incluido. Instala el conector de MySQL para Python antes de ejecutar el
+Si prefieres MySQL puedes utilizar el servicio incluido en XAMPP u otra
+instancia. Instala el conector `PyMySQL` para Python antes de ejecutar el
 servidor:
 
 ```bash


### PR DESCRIPTION
## Summary
- emphasize PostgreSQL as the main database
- create a dedicated optional MySQL section with extra requirements
- mention optional MySQL URI in `.env.example`

## Testing
- `pytest -q` *(fails: pyenv version `3.11.9` is not installed)*
- `pip install -r requirements.txt` *(fails: network access disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68538329d15083208f4da0d295bb93cf