### PR TITLE
Refactor error handler to separate module

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -2,10 +2,11 @@
 
 import logging
 import os
-from flask import Flask, jsonify
+from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
-from werkzeug.exceptions import HTTPException
 from urllib.parse import urlparse
+
+from backend.app.error_handlers import register_error_handlers
 
 # Ajuste automático de esquema para pg8000 o psycopg2
 url = os.getenv("DATABASE_URL", "")
@@ -46,14 +47,3 @@ def create_app():
     register_error_handlers(app)
 
     return app
-
-
-def register_error_handlers(app: Flask) -> None:
-    @app.errorhandler(HTTPException)
-    def handle_http_error(e: HTTPException):
-        return jsonify(error=e.description), e.code
-
-    @app.errorhandler(Exception)
-    def handle_exception(e: Exception):
-        logger.error("Unhandled exception", exc_info=True)
-        return jsonify(error="Internal server error"), 500

--- a/backend/app/error_handlers.py
+++ b/backend/app/error_handlers.py
@@ -1,0 +1,16 @@
+import logging
+from flask import Flask, jsonify
+from werkzeug.exceptions import HTTPException
+
+logger = logging.getLogger(__name__)
+
+
+def register_error_handlers(app: Flask) -> None:
+    @app.errorhandler(HTTPException)
+    def handle_http_error(e: HTTPException):
+        return jsonify(error=e.description), e.code
+
+    @app.errorhandler(Exception)
+    def handle_exception(e: Exception):
+        logger.error("Unhandled exception", exc_info=True)
+        return jsonify(error="Internal server error"), 500


### PR DESCRIPTION
## Summary
- keep config consistent for SQLAlchemy modifications flag
- move error handlers to `error_handlers.py`
- import and use `register_error_handlers` in config

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68546a6506488320b108f23b6723dd0d