### PR TITLE
Refactor error handlers

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -2,10 +2,11 @@
 
 import logging
 import os
-from flask import Flask, jsonify
+from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
-from werkzeug.exceptions import HTTPException
 from urllib.parse import urlparse
+
+from backend.app.error_handlers import register_error_handlers
 
 # Ajuste automático de esquema para pg8000 o psycopg2
 url = os.getenv("DATABASE_URL", "")
@@ -46,14 +47,3 @@ def create_app():
     register_error_handlers(app)
 
     return app
-
-
-def register_error_handlers(app: Flask) -> None:
-    @app.errorhandler(HTTPException)
-    def handle_http_error(e: HTTPException):
-        return jsonify(error=e.description), e.code
-
-    @app.errorhandler(Exception)
-    def handle_exception(e: Exception):
-        logger.error("Unhandled exception", exc_info=True)
-        return jsonify(error="Internal server error"), 500

--- a/backend/app/error_handlers.py
+++ b/backend/app/error_handlers.py
@@ -1,0 +1,19 @@
+import logging
+from flask import Flask, jsonify
+from werkzeug.exceptions import HTTPException
+
+logger = logging.getLogger(__name__)
+
+
+def register_error_handlers(app: Flask) -> None:
+    @app.errorhandler(HTTPException)
+    def handle_http_error(e: HTTPException):
+        return jsonify(error=e.description), e.code
+
+    @app.errorhandler(Exception)
+    def handle_exception(e: Exception):
+        logger.error("Unhandled exception", exc_info=True)
+        return jsonify(error="Internal server error"), 500
+
+
+__all__ = ["register_error_handlers"]


### PR DESCRIPTION
## Summary
- move Flask error handler registration out of config
- export `register_error_handlers` via `backend.app.error_handlers`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68546a66cad0832099aaa6803c525ab7