### PR TITLE
Switch DATABASE_URL example to MySQL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
-DATABASE_URL=postgresql://user:password@db:5432/kiba
+# DATABASE_URL=postgresql://user:password@db:5432/kiba
 # Para usar MySQL instala PyMySQL y ajusta la siguiente cadena
-# DATABASE_URL=mysql+pymysql://user:password@localhost:3306/kiba
+DATABASE_URL=mysql+pymysql://user:password@localhost:3306/kiba
 JWT_SECRET=change_me
 HABLAME_ACCOUNT=your_account
 HABLAME_APIKEY=your_apikey

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Copie el archivo `.env.example` a `.env` y complete con al menos:
 - `ADMIN_EMAIL` y `ADMIN_PASS` – datos del administrador inicial.
 - `SENTRY_DSN` – opcional, para reportar errores.
 
+El archivo `.env.example` contiene ejemplos para PostgreSQL y MySQL. Elija una de las URLs y deje la otra comentada. 
 ## Base de datos (PostgreSQL por defecto)
 
 Para desarrollo local utilizamos **PostgreSQL**. Cree la base de datos y ejecute


### PR DESCRIPTION
## Summary
- comment out the PostgreSQL DATABASE_URL
- activate the MySQL DATABASE_URL example
- explain in README that only one URL should be used

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68546a6c2d6483208a66254cc8770655