### PR TITLE
Clean requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,3 @@ pytest
 pg8000==1.31.2
 sentry-sdk>=1.39.1
 prometheus-client>=0.20.0
-psycopg2-binary>=2.9.6


### PR DESCRIPTION
## Summary
- drop unused psycopg2-binary from requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68546a6fa6b48320830b825b53910c35