### PR TITLE
Ensure app creation and add missing imports

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -3,6 +3,16 @@
 import logging
 import os
 
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from flask_migrate import Migrate
+from flask_cors import CORS
+from dotenv import load_dotenv
+from urllib.parse import urlparse
+from werkzeug.middleware.dispatcher import DispatcherMiddleware
+from prometheus_client import make_wsgi_app
+from sentry_sdk import init as sentry_init
+from sentry_sdk.integrations.flask import FlaskIntegration
 
 from backend.app.error_handlers import register_error_handlers
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,4 @@
 from backend.app.config import create_app
-import os
 
+app = create_app()
 


### PR DESCRIPTION
## Summary
- import flask-related modules in backend config
- initialize app in `main.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6854787f2d5883209e706f4511601ace