### PR TITLE
Update DATABASE_URL example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
-# DATABASE_URL=postgresql://user:password@db:5432/kiba
+# Ejemplo para PostgreSQL (valor por defecto)
+DATABASE_URL=postgresql://user:password@localhost:5432/kiba
 # Para usar MySQL instala PyMySQL y ajusta la siguiente cadena
-DATABASE_URL=mysql+pymysql://user:password@localhost:3306/kiba
+# DATABASE_URL=mysql+pymysql://user:password@localhost:3306/kiba
 JWT_SECRET=change_me
 HABLAME_ACCOUNT=your_account
 HABLAME_APIKEY=your_apikey


### PR DESCRIPTION
## Summary
- switch active DATABASE_URL example to PostgreSQL in `.env.example`
- keep MySQL string commented for reference

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68547880121883209fe94b57926a2e25