### PR TITLE
Fix PostgreSQL validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
-# DATABASE_URL=postgresql://user:password@db:5432/kiba
+# Cadena de conexión por defecto para PostgreSQL
+DATABASE_URL=postgresql://user:password@db:5432/kiba
 # Para usar MySQL instala PyMySQL y ajusta la siguiente cadena
-DATABASE_URL=mysql+pymysql://user:password@localhost:3306/kiba
+# DATABASE_URL=mysql+pymysql://user:password@localhost:3306/kiba
 JWT_SECRET=change_me
 HABLAME_ACCOUNT=your_account
 HABLAME_APIKEY=your_apikey

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -15,6 +15,17 @@ from dotenv import load_dotenv
 from sentry_sdk import init as sentry_init
 from sentry_sdk.integrations.flask import FlaskIntegration
 
+# Load environment variables from .env as soon as the module is imported
+load_dotenv()
+
+_env_url = os.getenv("DATABASE_URL")
+if not _env_url or not (
+    _env_url.startswith("postgres://") or _env_url.startswith("postgresql://")
+):
+    raise RuntimeError(
+        "DATABASE_URL debe definirse y usar el esquema de PostgreSQL"
+    )
+
 from backend.app.error_handlers import register_error_handlers
 
 # Leer la URL de la base de datos desde .env
@@ -54,7 +65,6 @@ migrate = Migrate()
 # Factory de aplicación
 def create_app():
     """Create and configure the Flask application."""
-    load_dotenv()
 
     app = Flask(__name__)
     app.config.from_mapping(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,17 +2,23 @@ import os
 import sys
 import pytest
 
+# Ensure valid DATABASE_URL before importing the config module
+os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/db")
+os.environ.setdefault("JWT_SECRET", "testsecret")
+
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from backend.app.config import create_app, db
+import backend.app.config as config
+db = config.db
 from backend.app.models.user import Rol, Usuario
 
 
 @pytest.fixture
 def app():
-    os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+    os.environ["DATABASE_URL"] = "postgresql://user:pass@localhost/db"
     os.environ["JWT_SECRET"] = "testsecret"
-    app = create_app()
+    config.SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    app = config.create_app()
     app.config["TESTING"] = True
     with app.app_context():
         db.create_all()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,24 +1,30 @@
 import os
-from backend.app.config import create_app
 import importlib
 import logging
+
+# Ensure a default DATABASE_URL so the module can be imported
+os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/db")
+os.environ.setdefault("JWT_SECRET", "testsecret")
+
+import backend.app.config as config
 
 def setup_env(url):
     os.environ["DATABASE_URL"] = url
     os.environ["JWT_SECRET"] = "testsecret"
+    importlib.reload(config)
 
 
 def test_postgres_url_usado(monkeypatch):
     url = "postgres://user:pass@localhost/db"
     setup_env(url)
-    app = create_app()
+    app = config.create_app()
     assert app.config["SQLALCHEMY_DATABASE_URI"] == url
 
 
 def test_postgresql_url_usado(monkeypatch):
     url = "postgresql://user:pass@localhost/db"
     setup_env(url)
-    app = create_app()
+    app = config.create_app()
     assert app.config["SQLALCHEMY_DATABASE_URI"] == url
 
 
@@ -26,6 +32,6 @@ def test_log_message_masked(monkeypatch, caplog):
     url = "postgresql://user:pass@localhost/db"
     setup_env(url)
     with caplog.at_level(logging.INFO):
-        importlib.reload(importlib.import_module("backend.app.config"))
+        importlib.reload(config)
     messages = "".join(record.getMessage() for record in caplog.records)
     assert "pass" not in messages


### PR DESCRIPTION
## Summary
- enable PostgreSQL connection string in example env file
- verify DATABASE_URL in config at import time
- keep fixtures working with the new validation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6854d3b0a7308320b6504d512bd5c942