### PR TITLE
Leer FRONTEND_URL para CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Copie el archivo `.env.example` a `.env` y complete con al menos:
 - `DATABASE_URL` – cadena de conexión para SQLAlchemy.
 - `JWT_SECRET` – clave secreta para firmar tokens.
 - `HABLAME_ACCOUNT`, `HABLAME_APIKEY`, `HABLAME_TOKEN` – credenciales del servicio SMS.
-- `FRONTEND_URL` – origen permitido para CORS.
+- `FRONTEND_URL` – origen permitido para CORS (si falta se usa `*`).
 - `ADMIN_EMAIL` y `ADMIN_PASS` – datos del administrador inicial.
 - `SENTRY_DSN` – opcional, para reportar errores.
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -67,7 +67,12 @@ def create_app():
     # Inicializar extensiones y registrar manejadores de error
     db.init_app(app)
     migrate.init_app(app, db)
-    CORS(app, resources={r"/api/*": {"origins": "*"}})
+
+    frontend_url = os.getenv("FRONTEND_URL")
+    if not frontend_url:
+        logger.warning("FRONTEND_URL no establecido, usando '*' para CORS")
+        frontend_url = "*"
+    CORS(app, resources={r"/api/*": {"origins": frontend_url}})
     register_error_handlers(app)
 
     if app.config.get("SENTRY_DSN"):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,3 +29,39 @@ def test_log_message_masked(monkeypatch, caplog):
         importlib.reload(importlib.import_module("backend.app.config"))
     messages = "".join(record.getMessage() for record in caplog.records)
     assert "pass" not in messages
+
+
+def test_cors_frontend_url_used(monkeypatch):
+    os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+    os.environ["JWT_SECRET"] = "secret"
+    os.environ["FRONTEND_URL"] = "https://front.test"
+
+    captured = {}
+
+    def fake_cors(app, resources):
+        captured["origins"] = resources[r"/api/*"]["origins"]
+
+    monkeypatch.setattr("backend.app.config.CORS", fake_cors)
+    importlib.reload(importlib.import_module("backend.app.config"))
+    from backend.app.config import create_app
+    create_app()
+    assert captured["origins"] == "https://front.test"
+
+
+def test_cors_default_wildcard_warning(monkeypatch, caplog):
+    os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+    os.environ["JWT_SECRET"] = "secret"
+    os.environ.pop("FRONTEND_URL", None)
+
+    captured = {}
+
+    def fake_cors(app, resources):
+        captured["origins"] = resources[r"/api/*"]["origins"]
+
+    monkeypatch.setattr("backend.app.config.CORS", fake_cors)
+    with caplog.at_level(logging.WARNING):
+        importlib.reload(importlib.import_module("backend.app.config"))
+        from backend.app.config import create_app
+        create_app()
+    assert captured["origins"] == "*"
+    assert any("FRONTEND_URL" in rec.getMessage() for rec in caplog.records)


### PR DESCRIPTION
## Summary
- make CORS read `FRONTEND_URL` inside `create_app`
- document default value in README
- test that CORS uses the env var and warns when missing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6854d3b20f1883208403ba5a0ccbc404