### PR TITLE
Fix frontend build directory path

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "vite build --outDir frontend/dist",
+    "build": "vite build --outDir dist",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -15,7 +15,7 @@ export default defineConfig(({ mode }) => {
       }
     },
     build: {
-      outDir: 'frontend/dist',
+      outDir: 'dist',
       chunkSizeWarningLimit: 500,
       rollupOptions: {
         output: {


### PR DESCRIPTION
## Summary
- configure Vite build output to use `frontend/dist`
- update npm build script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6854d3b5c164832085afe1acb570f897