### PR TITLE
Allow SECRET_KEY or JWT_SECRET

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,8 @@
 DATABASE_URL=postgresql://user:password@db:5432/kiba
 # Para usar MySQL instala PyMySQL y ajusta la siguiente cadena
 # DATABASE_URL=mysql+pymysql://user:password@localhost:3306/kiba
-JWT_SECRET=change_me
+# Se usa SECRET_KEY para firmar tokens (también se admite JWT_SECRET)
+SECRET_KEY=change_me
 HABLAME_ACCOUNT=your_account
 HABLAME_APIKEY=your_apikey
 HABLAME_TOKEN=your_token

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ PostgreSQL es la base de datos principal del proyecto e incluye autenticación p
 Copie el archivo `.env.example` a `.env` y complete con al menos:
 
 - `DATABASE_URL` – cadena de conexión para SQLAlchemy.
-- `JWT_SECRET` – clave secreta para firmar tokens.
+- `SECRET_KEY` – clave secreta para firmar tokens (también se acepta `JWT_SECRET`).
 - `HABLAME_ACCOUNT`, `HABLAME_APIKEY`, `HABLAME_TOKEN` – credenciales del servicio SMS.
 - `FRONTEND_URL` – origen permitido para CORS (si falta se usa `*`).
 - `ADMIN_EMAIL` y `ADMIN_PASS` – datos del administrador inicial.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -36,9 +36,11 @@ SQLALCHEMY_DATABASE_URI = _build_database_uri(DATABASE_URL)
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 
 # Clave secreta de Flask
-SECRET_KEY = os.getenv("SECRET_KEY")
+SECRET_KEY = os.getenv("SECRET_KEY") or os.getenv("JWT_SECRET")
 if not SECRET_KEY:
-    raise RuntimeError("SECRET_KEY debe definirse en las variables de entorno")
+    raise RuntimeError(
+        "SECRET_KEY o JWT_SECRET debe definirse en las variables de entorno"
+    )
 
 # Configuración de Sentry
 SENTRY_DSN = os.getenv("SENTRY_DSN") or None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import pytest
 
 # Ensure valid DATABASE_URL before importing the config module
 os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/db")
-os.environ.setdefault("JWT_SECRET", "testsecret")
+os.environ.setdefault("SECRET_KEY", "testsecret")
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -16,7 +16,7 @@ from backend.app.models.user import Rol, Usuario
 @pytest.fixture
 def app():
     os.environ["DATABASE_URL"] = "postgresql://user:pass@localhost/db"
-    os.environ["JWT_SECRET"] = "testsecret"
+    os.environ["SECRET_KEY"] = "testsecret"
     config.SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
     app = config.create_app()
     app.config["TESTING"] = True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,13 +4,13 @@ import logging
 
 # Ensure a default DATABASE_URL so the module can be imported
 os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/db")
-os.environ.setdefault("JWT_SECRET", "testsecret")
+os.environ.setdefault("SECRET_KEY", "testsecret")
 
 import backend.app.config as config
 
 def setup_env(url):
     os.environ["DATABASE_URL"] = url
-    os.environ["JWT_SECRET"] = "testsecret"
+    os.environ["SECRET_KEY"] = "testsecret"
     importlib.reload(config)
 
 
@@ -39,7 +39,7 @@ def test_log_message_masked(monkeypatch, caplog):
 
 def test_cors_frontend_url_used(monkeypatch):
     os.environ["DATABASE_URL"] = "sqlite:///:memory:"
-    os.environ["JWT_SECRET"] = "secret"
+    os.environ["SECRET_KEY"] = "secret"
     os.environ["FRONTEND_URL"] = "https://front.test"
 
     captured = {}
@@ -56,7 +56,7 @@ def test_cors_frontend_url_used(monkeypatch):
 
 def test_cors_default_wildcard_warning(monkeypatch, caplog):
     os.environ["DATABASE_URL"] = "sqlite:///:memory:"
-    os.environ["JWT_SECRET"] = "secret"
+    os.environ["SECRET_KEY"] = "secret"
     os.environ.pop("FRONTEND_URL", None)
 
     captured = {}


### PR DESCRIPTION
## Summary
- allow SECRET_KEY or JWT_SECRET in backend config
- clarify secret key usage in docs and `.env.example`
- update tests to use SECRET_KEY

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6854e437e3ec8320b11f974d68725365