### PR TITLE
Fix duplicate DATABASE_URL example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,8 @@ HABLAME_TOKEN=your_token
 FRONTEND_URL=http://localhost:3000
 ADMIN_EMAIL=admin@example.com
 ADMIN_PASS=Admin123!
+# Configure Sentry if desired
 SENTRY_DSN=
-DATABASE_URL=postgresql://kiba_user:VIVES17@localhost:5432/kiba_db
+# DATABASE_URL=postgresql://kiba_user:VIVES17@localhost:5432/kiba_db
 # Configuración de la base de datos PostgreSQL
 # Asegúrate de que la base de datos exista y el usuario tenga permisos


### PR DESCRIPTION
## Summary
- comment the second DATABASE_URL in `.env.example`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6854e438cc2883208561b7ef87a44cc8