### PR TITLE
Add success flag on login

### DIFF
--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -21,20 +21,24 @@ def login():
 
     if not correo or not contrasena:
         logger.warning("Login fallido: faltan datos")
-        return jsonify({'error': 'Correo y contraseña son obligatorios.'}), 400
+        return jsonify({'success': False,
+                        'error': 'Correo y contraseña son obligatorios.'}), 400
 
     usuario = Usuario.query.filter_by(correo=correo).first()
     if not usuario:
         logger.warning("Login fallido: usuario no encontrado")
-        return jsonify({'error': 'Usuario no encontrado.'}), 404
+        return jsonify({'success': False, 'error': 'Usuario no encontrado.'}), 404
 
     if not usuario.verificar_contrasena(contrasena):
         logger.warning("Login fallido: contraseña incorrecta")
-        return jsonify({'error': 'Contraseña incorrecta.'}), 401
+        return jsonify({'success': False, 'error': 'Contraseña incorrecta.'}), 401
 
     token = generar_token(usuario)
     logger.info("Login exitoso para %s", correo)
-    return jsonify({'mensaje': 'Login exitoso', 'token': token, 'rol': usuario.rol.nombre}), 200
+    return jsonify({'success': True,
+                    'mensaje': 'Login exitoso',
+                    'token': token,
+                    'rol': usuario.rol.nombre}), 200
 
 @auth.route('/crear-admin', methods=['POST'])
 def crear_admin():

--- a/tests/test_auth_endpoints.py
+++ b/tests/test_auth_endpoints.py
@@ -5,6 +5,7 @@ def test_login_success(client, seed_user):
     )
     assert resp.status_code == 200
     data = resp.get_json()
+    assert data["success"] is True
     assert "token" in data
     assert data["rol"] == "Administrador"
 


### PR DESCRIPTION
## Summary
- return `success` boolean from backend login route
- test for `success` in login response

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask>=3.1.0)*

------
https://chatgpt.com/codex/tasks/task_e_6854f0cd8a60832087709a607607776c