### PR TITLE
Use uvicorn for backend service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY backend ./backend
 ENV PYTHONUNBUFFERED=1
 EXPOSE 5000
-CMD ["gunicorn", "-b", "0.0.0.0:5000", "backend.app.main:app"]
+CMD ["uvicorn", "backend.app.main:app", "--host", "0.0.0.0", "--port", "5000"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ pytest
 pg8000==1.31.2
 sentry-sdk>=1.39.1
 prometheus-client>=0.20.0
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- run the backend with uvicorn by default
- include `fastapi` and `uvicorn` in requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6854f0d43c3083209a8073d6126007a0