### PR TITLE
Update Hablame API env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,9 +4,7 @@ DATABASE_URL=postgresql://user:password@db:5432/kiba
 # DATABASE_URL=mysql+pymysql://user:password@localhost:3306/kiba
 # Se usa SECRET_KEY para firmar tokens (también se admite JWT_SECRET)
 SECRET_KEY=change_me
-HABLAME_ACCOUNT=your_account
-HABLAME_APIKEY=your_apikey
-HABLAME_TOKEN=your_token
+HABLAME_API_KEY=your_api_key
 FRONTEND_URL=http://localhost:3000
 ADMIN_EMAIL=admin@example.com
 ADMIN_PASS=Admin123!

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Copie el archivo `.env.example` a `.env` y complete con al menos:
 
 - `DATABASE_URL` – cadena de conexión para SQLAlchemy.
 - `SECRET_KEY` – clave secreta para firmar tokens (también se acepta `JWT_SECRET`).
-- `HABLAME_ACCOUNT`, `HABLAME_APIKEY`, `HABLAME_TOKEN` – credenciales del servicio SMS.
+- `HABLAME_API_KEY` – credencial del servicio SMS.
 - `FRONTEND_URL` – origen permitido para CORS (si falta se usa `*`).
 - `ADMIN_EMAIL` y `ADMIN_PASS` – datos del administrador inicial.
 - `SENTRY_DSN` – opcional, para reportar errores.

--- a/backend/app/routes/sms.py
+++ b/backend/app/routes/sms.py
@@ -22,9 +22,7 @@ sms_bp = Blueprint('sms', __name__)
 def obtener_headers():
     return {
         "Content-Type": "application/json",
-        "Account": os.getenv("HABLAME_ACCOUNT"),
-        "ApiKey": os.getenv("HABLAME_APIKEY"),
-        "Token": os.getenv("HABLAME_TOKEN")
+        "ApiKey": os.getenv("HABLAME_API_KEY"),
     }
 
 # ========================


### PR DESCRIPTION
## Summary
- update `.env.example` to use `HABLAME_API_KEY`
- update documentation for the new variable
- adjust SMS configuration to read `HABLAME_API_KEY`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6854f0d4ea4083208ee041a1b9c73ed1