### PR TITLE
Update env variables docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,9 +2,16 @@
 DATABASE_URL=postgresql://user:password@db:5432/kiba
 # Para usar MySQL instala PyMySQL y ajusta la siguiente cadena
 # DATABASE_URL=mysql+pymysql://user:password@localhost:3306/kiba
-# Se usa SECRET_KEY para firmar tokens (también se admite JWT_SECRET)
+# Se usa SECRET_KEY para firmar tokens (también se admite JWT_SECRET o JWT_SECRET_KEY)
 SECRET_KEY=change_me
-HABLAME_API_KEY=dYJ2M6MQzaru6sZhWSC93tnbArQUAmqWxzdWpOJqBo4jnR3XmkED7juameQGf0dIj5vKGKliFgR731wTceTnkh4Lw9X1NwUEta6VyGgzN0bBMAq0OtDJxNPHTDZgH89o
+# Identificador de la cuenta en Hablame
+HABLAME_ACCOUNT=
+# ApiKey de la cuenta Hablame
+HABLAME_APIKEY=
+# Token de autenticación de Hablame
+HABLAME_TOKEN=
+# Alternativamente se puede usar esta clave en lugar de SECRET_KEY
+JWT_SECRET_KEY=
 FRONTEND_URL=http://localhost:3000
 ADMIN_EMAIL=admin@example.com
 ADMIN_PASS=Admin123!

--- a/README.md
+++ b/README.md
@@ -8,8 +8,11 @@ PostgreSQL es la base de datos principal del proyecto e incluye autenticación p
 Copie el archivo `.env.example` a `.env` y complete con al menos:
 
 - `DATABASE_URL` – cadena de conexión para SQLAlchemy.
-- `SECRET_KEY` – clave secreta para firmar tokens (también se acepta `JWT_SECRET`).
-- `HABLAME_API_KEY` – credencial del servicio SMS.
+- `SECRET_KEY` – clave secreta para firmar tokens (también se acepta `JWT_SECRET` o `JWT_SECRET_KEY`).
+- `JWT_SECRET_KEY` – alternativa opcional a `SECRET_KEY`.
+- `HABLAME_ACCOUNT` – identificador de la cuenta Hablame.
+- `HABLAME_APIKEY` – ApiKey de la cuenta Hablame.
+- `HABLAME_TOKEN` – token de autenticación para el servicio SMS.
 - `FRONTEND_URL` – origen permitido para CORS (si falta se usa `*`).
 - `ADMIN_EMAIL` y `ADMIN_PASS` – datos del administrador inicial.
 - `SENTRY_DSN` – opcional, para reportar errores.

--- a/backend/app/routes/sms.py
+++ b/backend/app/routes/sms.py
@@ -4,7 +4,6 @@ import logging
 from flask import Blueprint, request, jsonify
 import asyncio
 import json
-import os
 from datetime import datetime, timedelta
 from sqlalchemy import func
 from backend.app.config import db
@@ -16,16 +15,6 @@ from backend.app.hablame_client import HablameClient
 logger = logging.getLogger(__name__)
 sms_bp = Blueprint('sms', __name__)
 _hablame_client = HablameClient()
-
-# ========================
-# Funciones auxiliares
-# ========================
-
-def obtener_headers():
-    return {
-        "Content-Type": "application/json",
-        "ApiKey": os.getenv("HABLAME_API_KEY"),
-    }
 
 # ========================
 # Enviar SMS individual


### PR DESCRIPTION
## Summary
- update `.env.example` with SMS placeholders and JWT_SECRET_KEY
- document new SMS variables in README
- remove unused HABLAME_API_KEY code

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68558a6a4fa883209e06e984bd33059e