### PR TITLE
Add indexes and unique constraint updates

### DIFF
--- a/backend/app/models/cita.py
+++ b/backend/app/models/cita.py
@@ -7,9 +7,9 @@ class Cita(db.Model):
     __tablename__ = 'citas'
     
     id = db.Column(db.Integer, primary_key=True)
-    paciente_id = db.Column(db.Integer, db.ForeignKey('pacientes.id'), nullable=False)
-    especialidad_id = db.Column(db.Integer, db.ForeignKey('especialidades.id'), nullable=False)
-    fecha_hora = db.Column(db.DateTime, nullable=False)
+    paciente_id = db.Column(db.Integer, db.ForeignKey('pacientes.id'), nullable=False, index=True)
+    especialidad_id = db.Column(db.Integer, db.ForeignKey('especialidades.id'), nullable=False, index=True)
+    fecha_hora = db.Column(db.DateTime, nullable=False, index=True)
     creado_en = db.Column(db.DateTime, default=datetime.utcnow)
 
     # Relaciones

--- a/backend/app/models/confirmacion.py
+++ b/backend/app/models/confirmacion.py
@@ -7,9 +7,9 @@ class Confirmacion(db.Model):
     __tablename__ = 'confirmaciones'
 
     id = db.Column(db.Integer, primary_key=True)
-    cita_id = db.Column(db.Integer, db.ForeignKey('citas.id'), nullable=False)
-    sms_id = db.Column(db.Integer, db.ForeignKey('sms.id'), nullable=False)
-    confirmada_en = db.Column(db.DateTime, default=datetime.utcnow)
+    cita_id = db.Column(db.Integer, db.ForeignKey('citas.id'), nullable=False, index=True)
+    sms_id = db.Column(db.Integer, db.ForeignKey('sms.id'), nullable=False, index=True)
+    confirmada_en = db.Column(db.DateTime, default=datetime.utcnow, index=True)
 
     # Relaciones
     cita = db.relationship('Cita', back_populates='confirmaciones')

--- a/backend/app/models/paciente.py
+++ b/backend/app/models/paciente.py
@@ -9,8 +9,8 @@ class Paciente(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     nombre = db.Column(db.String(100), nullable=False)
     celular = db.Column(db.String(20), unique=True, nullable=False)
-    especialidad_id = db.Column(db.Integer, db.ForeignKey('especialidades.id'), nullable=False)
-    programada = db.Column(db.DateTime, nullable=True)
+    especialidad_id = db.Column(db.Integer, db.ForeignKey('especialidades.id'), nullable=False, index=True)
+    programada = db.Column(db.DateTime, nullable=True, index=True)
 
     especialidad = db.relationship('Especialidad', backref=db.backref('pacientes', lazy=True))
 

--- a/backend/app/models/sms.py
+++ b/backend/app/models/sms.py
@@ -6,7 +6,7 @@ from datetime import datetime
 class Especialidad(db.Model):
     __tablename__ = 'especialidades'
     id = db.Column(db.Integer, primary_key=True)
-    nombre = db.Column(db.String(100), nullable=False)
+    nombre = db.Column(db.String(100), nullable=False, unique=True, index=True)
 
     def __repr__(self):
         return f'<Especialidad {self.nombre}>'
@@ -17,9 +17,9 @@ class SMS(db.Model):
     celular = db.Column(db.String(20), nullable=False)
     mensaje = db.Column(db.Text, nullable=False)
     especialidad_id = db.Column(db.Integer, db.ForeignKey('especialidades.id'))
-    fecha_envio = db.Column(db.DateTime)
-    estado = db.Column(db.String(50))
-    token_confirmacion = db.Column(db.String(50), unique=True)
+    fecha_envio = db.Column(db.DateTime, index=True)
+    estado = db.Column(db.String(50), index=True)
+    token_confirmacion = db.Column(db.String(50), unique=True, index=True)
     confirmado = db.Column(db.Boolean, default=False)
 
     especialidad = db.relationship('Especialidad', backref='sms')

--- a/backend/app/models/sms_pendiente.py
+++ b/backend/app/models/sms_pendiente.py
@@ -9,8 +9,8 @@ class SMSPendiente(db.Model):
     celular = db.Column(db.String(20), nullable=False)
     mensaje = db.Column(db.Text, nullable=False)
     especialidad = db.Column(db.String(100))
-    fecha_programada = db.Column(db.DateTime)
-    estado = db.Column(db.String(20), default='pendiente')  # Estados posibles: pendiente, enviado, fallido
+    fecha_programada = db.Column(db.DateTime, index=True)
+    estado = db.Column(db.String(20), default='pendiente', index=True)  # Estados posibles: pendiente, enviado, fallido
 
     def __repr__(self):
         return f'<SMSPendiente {self.celular} - {self.estado}>'

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -14,7 +14,7 @@ class Rol(db.Model):
 class Usuario(db.Model):
     __tablename__ = 'usuarios'
     id = db.Column(db.Integer, primary_key=True)
-    correo = db.Column(db.String(100), unique=True, nullable=False)
+    correo = db.Column(db.String(100), unique=True, nullable=False, index=True)
     contrasena = db.Column(db.String(255), nullable=False)
     rol_id = db.Column(db.Integer, db.ForeignKey('roles.id'))
     rol = db.relationship('Rol', backref='usuarios')

--- a/migrations/versions/b2f9a1c4d567_add_indexes.py
+++ b/migrations/versions/b2f9a1c4d567_add_indexes.py
@@ -1,0 +1,35 @@
+"""Add indexes to frequently filtered columns
+
+Revision ID: b2f9a1c4d567
+Revises: 3f4319747613
+Create Date: 2025-06-20 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'b2f9a1c4d567'
+down_revision = '3f4319747613'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index('ix_sms_estado', 'sms', ['estado'])
+    op.create_index('ix_sms_fecha_envio', 'sms', ['fecha_envio'])
+    op.create_index('ix_citas_fecha_hora', 'citas', ['fecha_hora'])
+    op.create_index('ix_pacientes_programada', 'pacientes', ['programada'])
+    op.create_index('ix_confirmaciones_confirmada_en', 'confirmaciones', ['confirmada_en'])
+    op.create_index('ix_sms_pendientes_fecha_programada', 'sms_pendientes', ['fecha_programada'])
+    op.create_index('ix_sms_pendientes_estado', 'sms_pendientes', ['estado'])
+
+
+def downgrade():
+    op.drop_index('ix_sms_pendientes_estado', table_name='sms_pendientes')
+    op.drop_index('ix_sms_pendientes_fecha_programada', table_name='sms_pendientes')
+    op.drop_index('ix_confirmaciones_confirmada_en', table_name='confirmaciones')
+    op.drop_index('ix_pacientes_programada', table_name='pacientes')
+    op.drop_index('ix_citas_fecha_hora', table_name='citas')
+    op.drop_index('ix_sms_fecha_envio', table_name='sms')
+    op.drop_index('ix_sms_estado', table_name='sms')


### PR DESCRIPTION
## Summary
- index common columns for faster lookups
- keep `Especialidad.nombre` unique as in schema
- create Alembic migration for new indexes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685589f3b6948320bcd57ab34130a4fa