### PR TITLE
Use eager loading in SQLAlchemy models

### DIFF
--- a/backend/app/models/cita.py
+++ b/backend/app/models/cita.py
@@ -13,8 +13,16 @@ class Cita(db.Model):
     creado_en = db.Column(db.DateTime, default=datetime.utcnow)
 
     # Relaciones
-    paciente = db.relationship('Paciente', backref='citas')
-    especialidad = db.relationship('Especialidad', backref='citas')
+    paciente = db.relationship(
+        'Paciente',
+        backref=db.backref('citas', lazy='selectin'),
+        lazy='joined'
+    )
+    especialidad = db.relationship(
+        'Especialidad',
+        backref=db.backref('citas', lazy='selectin'),
+        lazy='joined'
+    )
     
     # Relación con confirmaciones
     confirmaciones = db.relationship('Confirmacion', back_populates='cita', cascade="all, delete-orphan")

--- a/backend/app/models/confirmacion.py
+++ b/backend/app/models/confirmacion.py
@@ -12,8 +12,16 @@ class Confirmacion(db.Model):
     confirmada_en = db.Column(db.DateTime, default=datetime.utcnow)
 
     # Relaciones
-    cita = db.relationship('Cita', back_populates='confirmaciones')
-    sms = db.relationship('SMS', backref='confirmaciones')
+    cita = db.relationship(
+        'Cita',
+        back_populates='confirmaciones',
+        lazy='joined'
+    )
+    sms = db.relationship(
+        'SMS',
+        backref=db.backref('confirmaciones', lazy='selectin'),
+        lazy='joined'
+    )
 
     def __repr__(self):
         return f'<Confirmacion {self.id} - Cita {self.cita_id} - SMS {self.sms_id}>'

--- a/backend/app/models/paciente.py
+++ b/backend/app/models/paciente.py
@@ -12,7 +12,11 @@ class Paciente(db.Model):
     especialidad_id = db.Column(db.Integer, db.ForeignKey('especialidades.id'), nullable=False)
     programada = db.Column(db.DateTime, nullable=True)
 
-    especialidad = db.relationship('Especialidad', backref=db.backref('pacientes', lazy=True))
+    especialidad = db.relationship(
+        'Especialidad',
+        backref=db.backref('pacientes', lazy='selectin'),
+        lazy='joined'
+    )
 
     def to_dict(self):
         return {

--- a/backend/app/models/sms.py
+++ b/backend/app/models/sms.py
@@ -22,7 +22,11 @@ class SMS(db.Model):
     token_confirmacion = db.Column(db.String(50), unique=True)
     confirmado = db.Column(db.Boolean, default=False)
 
-    especialidad = db.relationship('Especialidad', backref='sms')
+    especialidad = db.relationship(
+        'Especialidad',
+        backref=db.backref('sms', lazy='selectin'),
+        lazy='joined'
+    )
 
     def __repr__(self):
         return f'<SMS {self.celular}>'

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -17,7 +17,11 @@ class Usuario(db.Model):
     correo = db.Column(db.String(100), unique=True, nullable=False)
     contrasena = db.Column(db.String(255), nullable=False)
     rol_id = db.Column(db.Integer, db.ForeignKey('roles.id'))
-    rol = db.relationship('Rol', backref='usuarios')
+    rol = db.relationship(
+        'Rol',
+        backref=db.backref('usuarios', lazy='selectin'),
+        lazy='joined'
+    )
 
     def set_contrasena(self, contrasena_plana):
         self.contrasena = bcrypt.hashpw(contrasena_plana.encode('utf-8'), bcrypt.gensalt()).decode('utf-8')

--- a/backend/app/routes/confirmacion.py
+++ b/backend/app/routes/confirmacion.py
@@ -8,7 +8,6 @@ from backend.app.models.cita import Cita
 from backend.app.models.paciente import Paciente
 from backend.app.utils.token_manager import token_requerido
 from datetime import datetime, time
-from sqlalchemy.orm import joinedload
 
 logger = logging.getLogger(__name__)
 confirmacion_bp = Blueprint('confirmacion', __name__)
@@ -19,11 +18,7 @@ def obtener_confirmaciones():
     fecha_filtro = request.args.get('fecha')  # Formato esperado: YYYY-MM-DD
     paciente_id = request.args.get('paciente_id')
 
-    query = Confirmacion.query.options(
-        joinedload(Confirmacion.cita).joinedload(Cita.paciente),
-        joinedload(Confirmacion.cita).joinedload(Cita.especialidad),
-        joinedload(Confirmacion.sms),
-    )
+    query = Confirmacion.query
 
     joined = False
     if fecha_filtro or paciente_id:

--- a/backend/app/routes/paciente.py
+++ b/backend/app/routes/paciente.py
@@ -7,7 +7,6 @@ from backend.app.models.paciente import Paciente
 from backend.app.models.sms import Especialidad
 from backend.app.utils.token_manager import token_requerido
 from datetime import datetime
-from sqlalchemy.orm import selectinload
 
 
 logger = logging.getLogger(__name__)
@@ -51,7 +50,5 @@ def crear_paciente():
 @paciente_bp.route('/pacientes', methods=['GET'])
 @token_requerido
 def listar_pacientes():
-    pacientes = (
-        Paciente.query.options(selectinload(Paciente.especialidad)).all()
-    )
+    pacientes = Paciente.query.all()
     return jsonify([paciente.to_dict() for paciente in pacientes]), 200


### PR DESCRIPTION
## Summary
- tune SQLAlchemy relationships to use joined or selectin loading
- simplify patient list query
- remove joinedload from confirmation listing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685589f55c9c8320a5033cc34f386c02