### PR TITLE
Add DB health endpoint

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -123,6 +123,7 @@ def create_app():
     from backend.app.routes.cita import cita_bp
     from backend.app.routes.sms import sms_bp
     from backend.app.routes.confirmacion import confirmacion_bp
+    from backend.app.routes.health import health_bp
 
     app.register_blueprint(auth, url_prefix="/api")
     app.register_blueprint(specialty_bp, url_prefix="/api")
@@ -130,6 +131,7 @@ def create_app():
     app.register_blueprint(cita_bp, url_prefix="/api")
     app.register_blueprint(sms_bp, url_prefix="/api")
     app.register_blueprint(confirmacion_bp, url_prefix="/api")
+    app.register_blueprint(health_bp, url_prefix="/api")
 
     # Semilla de usuario admin por defecto
     from backend.app.utils.default_user import seed_default_admin

--- a/backend/app/routes/health.py
+++ b/backend/app/routes/health.py
@@ -1,0 +1,13 @@
+from flask import Blueprint, jsonify
+from sqlalchemy import text
+
+from backend.app.config import db
+
+health_bp = Blueprint('health', __name__)
+
+
+@health_bp.route('/v1/health/db', methods=['GET'])
+def db_health():
+    # Simple query to validate database connectivity
+    db.session.execute(text('SELECT 1'))
+    return jsonify({'status': 'ok'})

--- a/tests/test_health_endpoint.py
+++ b/tests/test_health_endpoint.py
@@ -1,0 +1,4 @@
+def test_db_health(client):
+    resp = client.get('/api/v1/health/db')
+    assert resp.status_code == 200
+    assert resp.get_json() == {'status': 'ok'}


### PR DESCRIPTION
## Summary
- add SQLAlchemy db healthcheck blueprint
- register new blueprint in `create_app`
- test the `/api/v1/health/db` endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685589f72fe08320a30d6818f8cbeda7