### PR TITLE
Add protected routes and new pages

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,23 +1,30 @@
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
+import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom'
 import Layout from './components/Layout'
+import ProtectedRoute from './components/ProtectedRoute'
 import Dashboard from './pages/Dashboard'
 import SendSMS from './pages/SendSMS'
 import ImportSMS from './pages/ImportSMS'
 import Reports from './pages/Reports'
 import Login from './pages/Login'
+import Register from './pages/Register'
+import Home from './pages/Home'
 
 export default function App() {
   return (
     <Router>
       <Routes>
         <Route path="/login" element={<Login />} />
-        <Route element={<Layout />}>
-          <Route path="/dashboard" element={<Dashboard />} />
-          <Route path="/send-sms" element={<SendSMS />} />
-          <Route path="/import-sms" element={<ImportSMS />} />
-          <Route path="/reports" element={<Reports />} />
+        <Route path="/register" element={<Register />} />
+        <Route element={<ProtectedRoute />}>
+          <Route element={<Layout />}>
+            <Route path="/" element={<Home />} />
+            <Route path="/dashboard" element={<Dashboard />} />
+            <Route path="/send-sms" element={<SendSMS />} />
+            <Route path="/import-sms" element={<ImportSMS />} />
+            <Route path="/reports" element={<Reports />} />
+          </Route>
         </Route>
-        <Route path="*" element={<Login />} />
+        <Route path="*" element={<Navigate to="/" />} />
       </Routes>
     </Router>
   )

--- a/frontend/src/AuthContext.jsx
+++ b/frontend/src/AuthContext.jsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useState } from 'react';
 
-const AuthContext = createContext({ token: null, user: null });
+const AuthContext = createContext({ token: null, user: null, login: () => {}, logout: () => {}, getUser: () => null });
 
 export function AuthProvider({ children }) {
   const [token, setToken] = useState(() => localStorage.getItem('token'));
@@ -23,8 +23,12 @@ export function AuthProvider({ children }) {
     localStorage.removeItem('user');
   };
 
+  const getUser = () => {
+    return user;
+  };
+
   return (
-    <AuthContext.Provider value={{ token, user, login, logout }}>
+    <AuthContext.Provider value={{ token, user, login, logout, getUser }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,15 +1,25 @@
-import { Link, Outlet } from 'react-router-dom'
+import { Link, Outlet, useNavigate } from 'react-router-dom'
+import { useAuth } from '../AuthContext'
 
 export default function Layout() {
+  const navigate = useNavigate();
+  const { logout } = useAuth();
+
+  const handleLogout = () => {
+    logout();
+    navigate('/login');
+  }
+
   return (
     <div>
       <header className="bg-blue-600 text-white">
         <nav className="container mx-auto p-4 flex gap-4">
+          <Link to="/">Inicio</Link>
           <Link to="/dashboard">Dashboard</Link>
           <Link to="/send-sms">Enviar SMS</Link>
           <Link to="/import-sms">Importar SMS</Link>
           <Link to="/reports">Reportes</Link>
-          <Link to="/login" className="ml-auto">Salir</Link>
+          <button onClick={handleLogout} className="ml-auto">Salir</button>
         </nav>
       </header>
       <main className="p-4">

--- a/frontend/src/components/ProtectedRoute.jsx
+++ b/frontend/src/components/ProtectedRoute.jsx
@@ -1,0 +1,10 @@
+import { Navigate, Outlet } from 'react-router-dom';
+import { useAuth } from '../AuthContext';
+
+export default function ProtectedRoute() {
+  const { token } = useAuth();
+  if (!token) {
+    return <Navigate to="/login" replace />;
+  }
+  return <Outlet />;
+}

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { useAuth } from '../AuthContext';
+
+export default function Home() {
+  const { getUser } = useAuth();
+  const user = getUser();
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4 text-blue-600">Bienvenido a CitaMatic</h1>
+      {user && <p className="text-gray-700">Sesión iniciada como {user.email}</p>}
+    </div>
+  );
+}

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -1,0 +1,60 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import api from '../api';
+
+export default function Register() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const navigate = useNavigate();
+
+  const handleRegister = async (e) => {
+    e.preventDefault();
+    setError('');
+    try {
+      const { data } = await api.post('/crear-admin', {
+        correo: email,
+        contrasena: password
+      });
+      if (data.mensaje) {
+        navigate('/login');
+      } else {
+        setError(data.error || 'Error al registrarse');
+      }
+    } catch {
+      setError('Error al registrarse');
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+      <form onSubmit={handleRegister} className="bg-white shadow-xl rounded-lg p-8 w-full max-w-md">
+        <h2 className="text-2xl font-bold text-blue-600 mb-6 text-center">Registro</h2>
+        {error && <div className="alert alert-danger mb-4">{error}</div>}
+        <div className="mb-4">
+          <label className="block mb-1 font-semibold">Email</label>
+          <input
+            type="email"
+            className="w-full border px-4 py-2 rounded-lg"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+        </div>
+        <div className="mb-6">
+          <label className="block mb-1 font-semibold">Contraseña</label>
+          <input
+            type="password"
+            className="w-full border px-4 py-2 rounded-lg"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+        </div>
+        <button type="submit" className="w-full bg-blue-600 text-white font-bold py-2 rounded-lg hover:bg-blue-700">
+          Registrarse
+        </button>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `ProtectedRoute` for auth guarding
- expand `AuthContext` with `getUser`
- create `Home` and `Register` pages
- update `Layout` with logout logic
- wire new pages and guards in router

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685589fafd508320ac0fae30e56ec351