### PR TITLE
Add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.3.0
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.2.5
+    hooks:
+      - id: prettier
+        files: ^frontend/.*\.(jsx?|tsx?|json|css|html|md|yml|yaml)
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v9.1.0
+    hooks:
+      - id: eslint
+        files: ^frontend/.*\.(jsx?|tsx?)
+

--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ Para análisis estático puedes instalar manualmente `mypy` y `bandit`. Estas
 dependencias no forman parte de `requirements.txt` para mantener liviano el
 entorno de producción.
 
+### Pre-commit
+
+Para ejecutar Black, Flake8 y las herramientas de frontend antes de cada
+commit instala los hooks con:
+
+```bash
+pre-commit install
+```
+
 ## Desarrollo del frontend
 
 Dentro de `frontend/` se encuentra el proyecto Vite + React:

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": ["eslint:recommended", "plugin:react/recommended"],
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  },
+  "rules": {}
+}
+


### PR DESCRIPTION
## Summary
- add pre-commit configuration to run Black, Flake8, ESLint and Prettier
- document installation of hooks in README
- provide minimal ESLint config for the frontend

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685589fcd4148320a0eee7d59b05a223