### PR TITLE
Update to single HABLAME env var

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -70,7 +70,7 @@ migrate = Migrate()
 # Factory de la aplicación
 def create_app():
     """Crea y configura la aplicación Flask."""
-    required_vars = ["HABLAME_ACCOUNT", "HABLAME_APIKEY", "HABLAME_TOKEN"]
+    required_vars = ["HABLAME_API_KEY"]
     missing = [var for var in required_vars if not os.getenv(var)]
     if missing:
         raise RuntimeError(

--- a/backend/app/hablame_client.py
+++ b/backend/app/hablame_client.py
@@ -6,18 +6,14 @@ from typing import Any, Dict, List
 class HablameClient:
     """Pequeño cliente async para la API de Hablame"""
 
-    def __init__(self, account: str | None = None, apikey: str | None = None, token: str | None = None, base_url: str = "https://api103.hablame.co/api"):
-        self.account = account or os.getenv("HABLAME_ACCOUNT")
-        self.apikey = apikey or os.getenv("HABLAME_APIKEY")
-        self.token = token or os.getenv("HABLAME_TOKEN")
+    def __init__(self, apikey: str | None = None, base_url: str = "https://api103.hablame.co/api"):
+        self.apikey = apikey or os.getenv("HABLAME_API_KEY")
         self.base_url = base_url.rstrip("/")
 
     def _headers(self) -> Dict[str, str]:
         return {
             "Content-Type": "application/json",
-            "Account": self.account or "",
             "ApiKey": self.apikey or "",
-            "Token": self.token or "",
         }
 
     async def ping(self) -> httpx.Response:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,7 @@ import pytest
 # Ensure valid DATABASE_URL before importing the config module
 os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/db")
 os.environ.setdefault("JWT_SECRET_KEY", "testsecret")
-os.environ.setdefault("HABLAME_ACCOUNT", "acc")
-os.environ.setdefault("HABLAME_APIKEY", "key")
-os.environ.setdefault("HABLAME_TOKEN", "token")
+os.environ.setdefault("HABLAME_API_KEY", "key")
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -20,9 +18,7 @@ from backend.app.models.user import Rol, Usuario
 def app():
     os.environ["DATABASE_URL"] = "postgresql://user:pass@localhost/db"
     os.environ["JWT_SECRET_KEY"] = "testsecret"
-    os.environ["HABLAME_ACCOUNT"] = "acc"
-    os.environ["HABLAME_APIKEY"] = "key"
-    os.environ["HABLAME_TOKEN"] = "token"
+    os.environ["HABLAME_API_KEY"] = "key"
     config.SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
     app = config.create_app()
     app.config["TESTING"] = True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,18 +6,14 @@ import pytest
 # Ensure a default DATABASE_URL so the module can be imported
 os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/db")
 os.environ.setdefault("JWT_SECRET_KEY", "testsecret")
-os.environ.setdefault("HABLAME_ACCOUNT", "acc")
-os.environ.setdefault("HABLAME_APIKEY", "key")
-os.environ.setdefault("HABLAME_TOKEN", "token")
+os.environ.setdefault("HABLAME_API_KEY", "key")
 
 import backend.app.config as config
 
 def setup_env(url):
     os.environ["DATABASE_URL"] = url
     os.environ["JWT_SECRET_KEY"] = "testsecret"
-    os.environ["HABLAME_ACCOUNT"] = "acc"
-    os.environ["HABLAME_APIKEY"] = "key"
-    os.environ["HABLAME_TOKEN"] = "token"
+    os.environ["HABLAME_API_KEY"] = "key"
     importlib.reload(config)
 
 
@@ -80,11 +76,7 @@ def test_cors_default_wildcard_warning(monkeypatch, caplog):
     assert any("FRONTEND_URL" in rec.getMessage() for rec in caplog.records)
 
 
-@pytest.mark.parametrize("missing", [
-    "HABLAME_ACCOUNT",
-    "HABLAME_APIKEY",
-    "HABLAME_TOKEN",
-])
+@pytest.mark.parametrize("missing", ["HABLAME_API_KEY"])
 def test_missing_hablame_vars_raises(missing):
     setup_env("sqlite:///:memory:")
     os.environ.pop(missing, None)

--- a/tests/test_hablame_client.py
+++ b/tests/test_hablame_client.py
@@ -5,7 +5,7 @@ from backend.app.hablame_client import HablameClient
 
 
 def test_send_sms_success():
-    client = HablameClient(account="a", apikey="b", token="c")
+    client = HablameClient(apikey="b")
     bulk = [{"numero": "1", "sms": "hi"}]
     with respx.mock as router:
         route = router.post("https://api103.hablame.co/api/sms/v3/send/marketing/bulk").mock(


### PR DESCRIPTION
## Summary
- require only `HABLAME_API_KEY` in config
- simplify `HablameClient` to use API key only
- update tests to new variable name

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6855a596f9b483209cc7c5c34ce2bc7d