### PR TITLE
Implement HablameClient improvements

### DIFF
--- a/backend/app/hablame_client.py
+++ b/backend/app/hablame_client.py
@@ -1,4 +1,5 @@
 import os
+import asyncio
 import httpx
 from typing import Any, Dict, List
 
@@ -6,29 +7,44 @@ from typing import Any, Dict, List
 class HablameClient:
     """Pequeño cliente async para la API de Hablame"""
 
-    def __init__(self, account: str | None = None, apikey: str | None = None, token: str | None = None, base_url: str = "https://api103.hablame.co/api"):
-        self.account = account or os.getenv("HABLAME_ACCOUNT")
-        self.apikey = apikey or os.getenv("HABLAME_APIKEY")
-        self.token = token or os.getenv("HABLAME_TOKEN")
+    def __init__(self, apikey: str | None = None, base_url: str = "https://api103.hablame.co/api"):
+        self.apikey = apikey or os.getenv("HABLAME_API_KEY")
         self.base_url = base_url.rstrip("/")
 
     def _headers(self) -> Dict[str, str]:
         return {
             "Content-Type": "application/json",
-            "Account": self.account or "",
             "ApiKey": self.apikey or "",
-            "Token": self.token or "",
         }
+
+    async def _request(self, method: str, url: str, **kwargs) -> httpx.Response:
+        """Realiza una petición HTTP con lógica de reintentos."""
+        retries_429 = 3
+        retries_5xx = 1
+        backoff = 1
+        while True:
+            async with httpx.AsyncClient() as client:
+                resp = await client.request(method, url, **kwargs)
+
+            if resp.status_code == 429 and retries_429 > 0:
+                await asyncio.sleep(backoff)
+                backoff *= 2
+                retries_429 -= 1
+                continue
+
+            if resp.status_code >= 500 and resp.status_code != 429 and retries_5xx > 0:
+                retries_5xx -= 1
+                continue
+
+            return resp
 
     async def ping(self) -> httpx.Response:
         url = f"{self.base_url}/sms/v3/ping"
-        async with httpx.AsyncClient() as client:
-            return await client.get(url, headers=self._headers())
+        return await self._request("GET", url, headers=self._headers())
 
     async def auth(self) -> httpx.Response:
         url = f"{self.base_url}/sms/v3/authenticate"
-        async with httpx.AsyncClient() as client:
-            return await client.post(url, headers=self._headers())
+        return await self._request("POST", url, headers=self._headers())
 
     async def send_sms(self, bulk: List[Dict[str, Any]]) -> httpx.Response:
         url = f"{self.base_url}/sms/v3/send/marketing/bulk"
@@ -38,6 +54,17 @@ class HablameClient:
             "request_dlvr_rcpt": "0",
             "bulk": bulk,
         }
-        async with httpx.AsyncClient() as client:
-            return await client.post(url, headers=self._headers(), json=payload)
+        return await self._request("POST", url, headers=self._headers(), json=payload)
+
+    async def get_sms_status(self, message_id: str) -> httpx.Response:
+        url = f"{self.base_url}/sms/v3/status/{message_id}"
+        return await self._request("GET", url, headers=self._headers())
+
+    async def get_account_info(self) -> httpx.Response:
+        url = f"{self.base_url}/sms/v3/account"
+        return await self._request("GET", url, headers=self._headers())
+
+    async def list_countries(self) -> httpx.Response:
+        url = f"{self.base_url}/sms/v3/country"
+        return await self._request("GET", url, headers=self._headers())
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ os.environ.setdefault("JWT_SECRET_KEY", "testsecret")
 os.environ.setdefault("HABLAME_ACCOUNT", "acc")
 os.environ.setdefault("HABLAME_APIKEY", "key")
 os.environ.setdefault("HABLAME_TOKEN", "token")
+os.environ.setdefault("HABLAME_API_KEY", "key")
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -23,6 +24,7 @@ def app():
     os.environ["HABLAME_ACCOUNT"] = "acc"
     os.environ["HABLAME_APIKEY"] = "key"
     os.environ["HABLAME_TOKEN"] = "token"
+    os.environ["HABLAME_API_KEY"] = "key"
     config.SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
     app = config.create_app()
     app.config["TESTING"] = True

--- a/tests/test_hablame_client.py
+++ b/tests/test_hablame_client.py
@@ -5,12 +5,45 @@ from backend.app.hablame_client import HablameClient
 
 
 def test_send_sms_success():
-    client = HablameClient(account="a", apikey="b", token="c")
+    client = HablameClient(apikey="b")
     bulk = [{"numero": "1", "sms": "hi"}]
     with respx.mock as router:
         route = router.post("https://api103.hablame.co/api/sms/v3/send/marketing/bulk").mock(
             return_value=httpx.Response(200, json_data={"ok": True})
         )
         resp = asyncio.run(client.send_sms(bulk))
+        assert resp.status_code == 200
+        assert route.called
+
+
+def test_get_sms_status():
+    client = HablameClient(apikey="b")
+    with respx.mock as router:
+        route = router.get("https://api103.hablame.co/api/sms/v3/status/123").mock(
+            return_value=httpx.Response(200, json_data={"ok": True})
+        )
+        resp = asyncio.run(client.get_sms_status("123"))
+        assert resp.status_code == 200
+        assert route.called
+
+
+def test_get_account_info():
+    client = HablameClient(apikey="b")
+    with respx.mock as router:
+        route = router.get("https://api103.hablame.co/api/sms/v3/account").mock(
+            return_value=httpx.Response(200, json_data={"ok": True})
+        )
+        resp = asyncio.run(client.get_account_info())
+        assert resp.status_code == 200
+        assert route.called
+
+
+def test_list_countries():
+    client = HablameClient(apikey="b")
+    with respx.mock as router:
+        route = router.get("https://api103.hablame.co/api/sms/v3/country").mock(
+            return_value=httpx.Response(200, json_data={"ok": True})
+        )
+        resp = asyncio.run(client.list_countries())
         assert resp.status_code == 200
         assert route.called


### PR DESCRIPTION
## Summary
- look up API key from `HABLAME_API_KEY`
- drop old auth parameters
- add `_request` helper with retry support
- implement new API helper methods
- update tests for new interface

## Testing
- `pip install -r requirements.txt` *(fails: Could not find Flask)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6855a598cc908320ac85118ae0c73d48