### PR TITLE
Add index to Cita.creado_en

### DIFF
--- a/backend/app/models/cita.py
+++ b/backend/app/models/cita.py
@@ -10,7 +10,7 @@ class Cita(db.Model):
     paciente_id = db.Column(db.Integer, db.ForeignKey('pacientes.id'), nullable=False, index=True)
     especialidad_id = db.Column(db.Integer, db.ForeignKey('especialidades.id'), nullable=False, index=True)
     fecha_hora = db.Column(db.DateTime, nullable=False, index=True)
-    creado_en = db.Column(db.DateTime, default=datetime.utcnow)
+    creado_en = db.Column(db.DateTime, default=datetime.utcnow, index=True)
 
     # Relaciones
     paciente = db.relationship(

--- a/migrations/versions/92f9a2d4d89b_add_index_creado_en.py
+++ b/migrations/versions/92f9a2d4d89b_add_index_creado_en.py
@@ -1,0 +1,23 @@
+"""Add index to Cita.creado_en
+
+Revision ID: 92f9a2d4d89b
+Revises: b2f9a1c4d567
+Create Date: 2025-06-21 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '92f9a2d4d89b'
+down_revision = 'b2f9a1c4d567'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index('ix_citas_creado_en', 'citas', ['creado_en'])
+
+
+def downgrade():
+    op.drop_index('ix_citas_creado_en', table_name='citas')


### PR DESCRIPTION
## Summary
- add an index to the `creado_en` column in the Cita model
- create an Alembic migration to create/drop the new index

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6855a59d0a448320a22e8afb5741de51