### PR TITLE
Update Hablame env var name

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -70,7 +70,7 @@ migrate = Migrate()
 # Factory de la aplicación
 def create_app():
     """Crea y configura la aplicación Flask."""
-    required_vars = ["HABLAME_ACCOUNT", "HABLAME_APIKEY", "HABLAME_TOKEN"]
+    required_vars = ["HABLAME_API_KEY"]
     missing = [var for var in required_vars if not os.getenv(var)]
     if missing:
         raise RuntimeError(

--- a/backend/app/hablame_client.py
+++ b/backend/app/hablame_client.py
@@ -7,9 +7,9 @@ class HablameClient:
     """Pequeño cliente async para la API de Hablame"""
 
     def __init__(self, account: str | None = None, apikey: str | None = None, token: str | None = None, base_url: str = "https://api103.hablame.co/api"):
-        self.account = account or os.getenv("HABLAME_ACCOUNT")
-        self.apikey = apikey or os.getenv("HABLAME_APIKEY")
-        self.token = token or os.getenv("HABLAME_TOKEN")
+        self.account = account or os.getenv("HABLAME_API_KEY")
+        self.apikey = apikey or os.getenv("HABLAME_API_KEY")
+        self.token = token or os.getenv("HABLAME_API_KEY")
         self.base_url = base_url.rstrip("/")
 
     def _headers(self) -> Dict[str, str]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,7 @@ import pytest
 # Ensure valid DATABASE_URL before importing the config module
 os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/db")
 os.environ.setdefault("JWT_SECRET_KEY", "testsecret")
-os.environ.setdefault("HABLAME_ACCOUNT", "acc")
-os.environ.setdefault("HABLAME_APIKEY", "key")
-os.environ.setdefault("HABLAME_TOKEN", "token")
+os.environ.setdefault("HABLAME_API_KEY", "key")
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -20,9 +18,7 @@ from backend.app.models.user import Rol, Usuario
 def app():
     os.environ["DATABASE_URL"] = "postgresql://user:pass@localhost/db"
     os.environ["JWT_SECRET_KEY"] = "testsecret"
-    os.environ["HABLAME_ACCOUNT"] = "acc"
-    os.environ["HABLAME_APIKEY"] = "key"
-    os.environ["HABLAME_TOKEN"] = "token"
+    os.environ["HABLAME_API_KEY"] = "key"
     config.SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
     app = config.create_app()
     app.config["TESTING"] = True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,18 +6,14 @@ import pytest
 # Ensure a default DATABASE_URL so the module can be imported
 os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/db")
 os.environ.setdefault("JWT_SECRET_KEY", "testsecret")
-os.environ.setdefault("HABLAME_ACCOUNT", "acc")
-os.environ.setdefault("HABLAME_APIKEY", "key")
-os.environ.setdefault("HABLAME_TOKEN", "token")
+os.environ.setdefault("HABLAME_API_KEY", "key")
 
 import backend.app.config as config
 
 def setup_env(url):
     os.environ["DATABASE_URL"] = url
     os.environ["JWT_SECRET_KEY"] = "testsecret"
-    os.environ["HABLAME_ACCOUNT"] = "acc"
-    os.environ["HABLAME_APIKEY"] = "key"
-    os.environ["HABLAME_TOKEN"] = "token"
+    os.environ["HABLAME_API_KEY"] = "key"
     importlib.reload(config)
 
 
@@ -81,9 +77,7 @@ def test_cors_default_wildcard_warning(monkeypatch, caplog):
 
 
 @pytest.mark.parametrize("missing", [
-    "HABLAME_ACCOUNT",
-    "HABLAME_APIKEY",
-    "HABLAME_TOKEN",
+    "HABLAME_API_KEY",
 ])
 def test_missing_hablame_vars_raises(missing):
     setup_env("sqlite:///:memory:")


### PR DESCRIPTION
## Summary
- consolidate environment variables used for Hablame API
- update config check for new variable
- adjust tests to use HABLAME_API_KEY

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6855a59a922c8320b0cb5e326fef2d33