### PR TITLE
Add configurable JWT expiration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ DATABASE_URL=postgresql://user:password@db:5432/kiba
 FRONTEND_URL=http://localhost:3000
 ADMIN_EMAIL=admin@example.com
 LOG_LEVEL=INFO
+JWT_EXPIRES_HOURS=1
 ADMIN_PASS=Admin123!
 # Configure Sentry if desired
 SENTRY_DSN=

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Copie el archivo `.env.example` a `.env` y complete con al menos:
 - `ADMIN_EMAIL` y `ADMIN_PASS` – datos del administrador inicial.
 - `SENTRY_DSN` – opcional, para reportar errores.
 - `LOG_LEVEL` – opcional, nivel de logging (INFO por defecto).
+- `JWT_EXPIRES_HOURS` – opcional, horas de validez del token (1 por defecto).
 
 El archivo `.env.example` contiene ejemplos para PostgreSQL y MySQL. Elija una de las URLs y deje la otra comentada. 
 ## Base de datos (PostgreSQL por defecto)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -41,6 +41,9 @@ JWT_SECRET_KEY = os.getenv("JWT_SECRET_KEY")
 if not JWT_SECRET_KEY:
     raise RuntimeError("JWT_SECRET_KEY debe definirse en las variables de entorno")
 
+# Tiempo de expiración del JWT en horas
+JWT_EXPIRES_HOURS = int(os.getenv("JWT_EXPIRES_HOURS", 1))
+
 # Configuración de Sentry
 SENTRY_DSN = os.getenv("SENTRY_DSN") or None
 
@@ -84,6 +87,7 @@ def create_app():
         SQLALCHEMY_TRACK_MODIFICATIONS=SQLALCHEMY_TRACK_MODIFICATIONS,
         SECRET_KEY=SECRET_KEY,
         JWT_SECRET_KEY=JWT_SECRET_KEY,
+        JWT_EXPIRES_HOURS=JWT_EXPIRES_HOURS,
         SENTRY_DSN=SENTRY_DSN,
     )
 

--- a/backend/app/utils/token_manager.py
+++ b/backend/app/utils/token_manager.py
@@ -9,11 +9,13 @@ from backend.app.models.user import Usuario
 
 # Función para generar el token
 def generar_token(usuario):
+    # Tiempo de expiración configurable (horas)
+    horas = current_app.config.get('JWT_EXPIRES_HOURS', 1)
     payload = {
         'id': usuario.id,
         'correo': usuario.correo,
         'rol': usuario.rol.nombre,
-        'exp': datetime.datetime.utcnow() + datetime.timedelta(hours=12)  # Válido por 12 horas
+        'exp': datetime.datetime.utcnow() + datetime.timedelta(hours=horas)
     }
     secret = current_app.config['JWT_SECRET_KEY']
     token = jwt.encode(payload, secret, algorithm='HS256')


### PR DESCRIPTION
## Summary
- support JWT_EXPIRES_HOURS environment variable
- use JWT_EXPIRES_HOURS when generating tokens
- document the setting in README and `.env.example`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6855a59f1130832087a8a98de4080072