### PR TITLE
Document health endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ flask --app backend.app.main run
 ```
 
 La API estará disponible en `http://localhost:5000/`.
+Puedes verificar la conexión a la base de datos visitando
+`http://localhost:5000/api/v1/health/db`.
 ## Autenticación
 
 Obten un token mediante la ruta `/api/login` enviando `correo` y `contrasena`.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -138,7 +138,8 @@ def create_app():
     with app.app_context():
         seed_default_admin()
 
-    # Rutas de salud
+    # Rutas de salud. Incluye la verificación de base de datos en
+    # ``/api/v1/health/db`` además de las rutas básicas ``/`` y ``/health``.
     @app.route("/")
     def home():
         return "CitaMatic Backend funcionando correctamente ✅"

--- a/backend/app/routes/health.py
+++ b/backend/app/routes/health.py
@@ -8,6 +8,10 @@ health_bp = Blueprint('health', __name__)
 
 @health_bp.route('/v1/health/db', methods=['GET'])
 def db_health():
-    # Simple query to validate database connectivity
+    """Return OK when the database connection is alive.
+
+    Endpoint available at ``/api/v1/health/db`` once the blueprint is
+    registered with the ``/api`` prefix.
+    """
     db.session.execute(text('SELECT 1'))
     return jsonify({'status': 'ok'})


### PR DESCRIPTION
## Summary
- document database health check URL in README
- clarify health check paths in code comments

## Testing
- `pytest -k health -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6855a59fca1083208c54d9c802b0e504