### PR TITLE
Add API wrapper for Hablame

### DIFF
--- a/frontend/src/api/hablame.ts
+++ b/frontend/src/api/hablame.ts
@@ -1,0 +1,16 @@
+import axios, { AxiosRequestConfig } from 'axios';
+
+const hablame = axios.create({
+  baseURL: `${import.meta.env.VITE_API_URL}/api`
+});
+
+hablame.interceptors.request.use((config: AxiosRequestConfig) => {
+  const token = localStorage.getItem('token');
+  if (token) {
+    if (!config.headers) config.headers = {};
+    (config.headers as any).Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+export default hablame;

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import api from '../api';
+import hablame from '../api/hablame';
 import { Bar } from 'react-chartjs-2';
 import {
   Chart as ChartJS,
@@ -23,7 +23,7 @@ export default function Dashboard() {
   });
 
   useEffect(() => {
-    api.get('/dashboard')
+    hablame.get('/dashboard')
       .then(res => setEstadisticas(res.data))
       .catch(err => console.error('Error cargando dashboard:', err));
   }, []);

--- a/frontend/src/pages/ImportSMS.jsx
+++ b/frontend/src/pages/ImportSMS.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import * as XLSX from 'xlsx';
-import api from '../api';
+import hablame from '../api/hablame';
 
 export default function ImportSMS() {
   const [archivo, setArchivo] = useState(null);
@@ -24,7 +24,7 @@ export default function ImportSMS() {
 
   const enviarSMSMasivos = async () => {
     try {
-      const response = await api.post('/importar-sms', {
+      const response = await hablame.post('/importar-sms', {
         mensajes: datos,
       });
 

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,7 +1,7 @@
 // frontend/src/pages/Login.jsx
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import api from '../api';
+import hablame from '../api/hablame';
 import { useAuth } from '../AuthContext';
 
 export default function Login() {
@@ -19,7 +19,7 @@ export default function Login() {
     setPasswordError('');
     setGenericError('');
     try {
-      const { data } = await api.post('/login', {
+      const { data } = await hablame.post('/login', {
         correo: email,
         contrasena: password,
       });

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import api from '../api';
+import hablame from '../api/hablame';
 
 export default function Register() {
   const [email, setEmail] = useState('');
@@ -12,7 +12,7 @@ export default function Register() {
     e.preventDefault();
     setError('');
     try {
-      const { data } = await api.post('/crear-admin', {
+      const { data } = await hablame.post('/crear-admin', {
         correo: email,
         contrasena: password
       });

--- a/frontend/src/pages/Reports.jsx
+++ b/frontend/src/pages/Reports.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import api from '../api';
+import hablame from '../api/hablame';
 import * as XLSX from 'xlsx';
 import { saveAs } from 'file-saver';
 import jsPDF from 'jspdf';
@@ -9,7 +9,7 @@ export default function Reports() {
   const [historial, setHistorial] = useState([]);
 
   useEffect(() => {
-    api.get('/historial')
+    hablame.get('/historial')
       .then(res => setHistorial(res.data))
       .catch(err => console.error('Error al cargar historial:', err));
   }, []);

--- a/frontend/src/pages/SendSMS.jsx
+++ b/frontend/src/pages/SendSMS.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import api from '../api';
+import hablame from '../api/hablame';
 
 export default function SendSMS() {
   const [numero, setNumero] = useState('');
@@ -13,7 +13,7 @@ export default function SendSMS() {
     setRespuesta(null);
 
     try {
-      const res = await api.post('/enviar-sms', {
+      const res = await hablame.post('/enviar-sms', {
         numero,
         mensaje
       });


### PR DESCRIPTION
## Summary
- add `frontend/src/api/hablame.ts` axios wrapper
- update pages to use the new wrapper

## Testing
- `pre-commit run --files frontend/src/api/hablame.ts frontend/src/pages/Dashboard.jsx frontend/src/pages/ImportSMS.jsx frontend/src/pages/Login.jsx frontend/src/pages/Register.jsx frontend/src/pages/Reports.jsx frontend/src/pages/SendSMS.jsx` *(fails: command not found)*
- `pip install pre-commit` *(fails: network access denied)*

------
https://chatgpt.com/codex/tasks/task_e_6855a5a1153483208d80a8da5079d4b9