### PR TITLE
Switch backend to gunicorn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY backend ./backend
 ENV PYTHONUNBUFFERED=1
 EXPOSE 5000
-CMD ["uvicorn", "backend.app.main:app", "--host", "0.0.0.0", "--port", "5000"]
+CMD ["gunicorn", "-w", "4", "-b", "0.0.0.0:5000", "backend.app.main:app"]

--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ Puede construir la imagen y levantar todo el entorno con:
 docker-compose up --build
 ```
 
+El servicio de backend se ejecuta con **Gunicorn** usando 4 procesos y
+escuchando en `0.0.0.0:5000`.
+
 ## Uso opcional con MySQL
 
 Si prefieres MySQL puedes utilizar el servicio incluido en XAMPP u otra

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,3 @@ pytest
 pg8000==1.31.2
 sentry-sdk>=1.39.1
 prometheus-client>=0.20.0
-fastapi
-uvicorn


### PR DESCRIPTION
## Summary
- run the Flask app using gunicorn in `Dockerfile`
- remove unused `fastapi` and `uvicorn` dependencies
- mention gunicorn in the Docker section of the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install -r requirements.txt` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686298da2fd48320ab078b038c82eda6