### PR TITLE
Add Poetry instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,20 @@ python manage.py cargar_datos
 flask --app backend.app.main run
 ```
 
+### Instalación con Poetry
+
+Si prefieres utilizar *Poetry* para manejar las dependencias, ejecuta:
+
+```bash
+pip install poetry        # o usa el instalador oficial
+cd backend
+poetry lock               # genera/actualiza poetry.lock
+poetry install            # instala las dependencias
+```
+
+Ten en cuenta que el `Dockerfile` espera los archivos `pyproject.toml` y
+`poetry.lock` dentro de `backend/`.
+
 En otra terminal inicie el frontend:
 
 ```bash


### PR DESCRIPTION
## Summary
- add new section about installing backend with Poetry
- note that Dockerfile expects `pyproject.toml` and `poetry.lock`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6862ccc38c3c832084b7d7b4d1853e0f