### PR TITLE
Fix README command for example data

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ source venv/bin/activate
 pip install -r requirements.txt
 cp .env.example .env
 flask --app backend.app.main db upgrade
-python manage.py cargar_datos
+flask --app backend.app.main cargar-datos
 flask --app backend.app.main run
 ```
 


### PR DESCRIPTION
## Summary
- update README to use `flask --app backend.app.main cargar-datos`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `cd frontend && npm test --silent` *(fails: tool version resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_68883c558ffc8320a70d01c5808087e1