### PR TITLE
Remove unused npm test docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,12 +120,6 @@ npm run build
 pytest
 ```
 
-### Frontend
-
-```bash
-cd frontend
-npm test
-```
 
 
 ## Docker


### PR DESCRIPTION
## Summary
- remove obsolete `npm test` instructions from README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68883c597bfc83209a3d2fcf27a34e10