### PR TITLE
Allow MySQL DATABASE_URL

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -22,8 +22,21 @@ load_dotenv()
 
 # Validar configuración de base de datos
 DATABASE_URL = os.getenv("DATABASE_URL")
-if not DATABASE_URL or not (DATABASE_URL.startswith("postgres://") or DATABASE_URL.startswith("postgresql://")):
-    raise RuntimeError("DATABASE_URL debe definirse y usar el esquema de PostgreSQL")
+if not DATABASE_URL:
+    raise RuntimeError(
+        "DATABASE_URL debe definirse y usar el esquema de PostgreSQL o MySQL"
+    )
+
+_allowed_schemes = (
+    "postgres://",
+    "postgresql://",
+    "mysql://",
+    "mysql+pymysql://",
+)
+if not DATABASE_URL.startswith(_allowed_schemes):
+    raise RuntimeError(
+        "DATABASE_URL debe usar PostgreSQL (postgres:// o postgresql://) o MySQL"
+    )
 
 # Construir URI de SQLAlchemy
 def _build_database_uri(url: str) -> str:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,6 +31,13 @@ def test_postgresql_url_usado(monkeypatch):
     assert app.config["SQLALCHEMY_DATABASE_URI"] == url
 
 
+def test_mysql_url_convertido(monkeypatch):
+    url = "mysql://user:pass@localhost/db"
+    setup_env(url)
+    app = config.create_app()
+    assert app.config["SQLALCHEMY_DATABASE_URI"] == "mysql+pymysql://user:pass@localhost/db"
+
+
 def test_log_message_masked(monkeypatch, caplog):
     url = "postgresql://user:pass@localhost/db"
     setup_env(url)


### PR DESCRIPTION
## Summary
- expand supported DB schemes to include MySQL in backend config
- test automatic conversion of mysql:// URLs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68883c59c5f883208233e6cb4beba5b4