### PR TITLE
Add httpx dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pytest
 pg8000==1.31.2
 sentry-sdk>=1.39.1
 prometheus-client>=0.20.0
+httpx>=0.27.0


### PR DESCRIPTION
## Summary
- include `httpx` in Python requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68883c5b71e483208164b011358d4e69