### PR TITLE
Clean README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,19 +43,6 @@ python manage.py cargar_datos
 flask --app backend.app.main run
 ```
 
-### Instalación con Poetry
-
-Si prefieres utilizar *Poetry* para manejar las dependencias, ejecuta:
-
-```bash
-pip install poetry        # o usa el instalador oficial
-cd backend
-poetry lock               # genera/actualiza poetry.lock
-poetry install            # instala las dependencias
-```
-
-Ten en cuenta que el `Dockerfile` espera los archivos `pyproject.toml` y
-`poetry.lock` dentro de `backend/`.
 
 En otra terminal inicie el frontend:
 


### PR DESCRIPTION
## Summary
- remove old Poetry setup instructions from README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask>=3.1.0)*

------
https://chatgpt.com/codex/tasks/task_e_68883c5c858c832088aefec8a394ea9c